### PR TITLE
feat: add multi-tenant support with mTLS identification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,9 +35,10 @@ internal/
   inject/                header/query injection, ${VAR} template resolution
   listener/              TCP + vsock listener factory, connection limiter
   policy/                PolicyEngine interface, host/path glob, first-match-wins
-  proxy/                 HTTP forward proxy + HTTPS CONNECT MITM handler
+  proxy/                 HTTP forward proxy + HTTPS CONNECT MITM handler, TenantResolver
   secrets/               SecretSource interface: env, file, vault, kubernetes, github-app
   telemetry/             TelemetryExporter interface: slog JSON, OTLP/HTTP, multi-exporter
+  tenant/                Tenant store interface, per-tenant config, FileStore with hot reload
   version/               version/commit/date vars (injected via ldflags)
 ```
 
@@ -45,9 +46,11 @@ internal/
 
 All interfaces take `context.Context` first param. See [Development](docs/development.md) for full signatures.
 
+- **TenantResolver** — `Resolve(r *http.Request) (*resolvedTenant, error)`. All policy/secret access goes through this. Implementations: SingleTenantResolver, MTLSTenantResolver.
 - **PolicyEngine** — `Evaluate` (first-match-wins, default-deny) + `CanMatchHost` (early CONNECT rejection)
 - **SecretSource** — `Resolve(ctx, name) (string, bool, error)`. Implementations: env, file, vault, kubernetes, github-app. See [Secrets](docs/secrets.md).
 - **TelemetryExporter** — `LogRequest`, `StartSpan`, `RecordMetric`, `Close`. Implementations: slog, OTLP/HTTP, multi. See [Telemetry](docs/telemetry.md).
+- **Tenant Store** — `Get(ctx, tenantID)` + `List(ctx)` + `Close()`. Implementation: FileStore (directory of YAML files, hot reload).
 
 ## Request Flow
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Warden solves this by performing TLS interception:
 
 ## Architecture
 
-Warden runs alongside agents — one instance per agent or agent type. The agent connects to Warden over TCP or vsock depending on the deployment model. NetworkPolicy ensures agents can only reach the internet through Warden. See [Deployment](docs/deployment.md) for full setup guides.
+Warden runs alongside agents. In **single-tenant** mode, one instance serves one agent. In **multi-tenant** mode, a single instance serves multiple agents, each identified by mTLS client certificate with isolated policies and secrets. Agents connect over TCP or vsock. NetworkPolicy or Security Groups ensure agents can only reach the internet through Warden. See [Deployment](docs/deployment.md) for full setup guides.
 
 **Kubernetes / OpenShift (separate pods, NetworkPolicy enforced):**
 
@@ -64,6 +64,17 @@ Warden runs alongside agents — one instance per agent or agent type. The agent
 | HTTPS | yes | MITM — TLS termination, inspection, re-encryption |
 | HTTP/2 | yes | Transparent via Go stdlib. Works with gRPC (`/package.Service/Method`) |
 | WebSocket | upgrade only | Policy evaluated on upgrade request. Frames pass through post-upgrade |
+
+**Multi-Tenant (mTLS, multiple agents per Warden):**
+
+```
+Agent EC2 A ──mTLS──▶ ┌─────────────────────┐
+  (CN=alpha)          │      Warden          │
+Agent EC2 B ──mTLS──▶ │  tenant resolution   │──▶ upstream
+  (CN=beta)           │  per-tenant policies  │
+Agent EC2 C ──mTLS──▶ │  per-tenant secrets   │
+  (CN=gamma)          └─────────────────────┘
+```
 
 ## Quick Start
 

--- a/cmd/warden-bridge/main.go
+++ b/cmd/warden-bridge/main.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"flag"
+	"fmt"
 	"log/slog"
 	"net"
 	"os"
@@ -14,12 +17,27 @@ import (
 
 func main() {
 	listenAddr := flag.String("listen", "127.0.0.1:8080", "TCP listen address")
-	vsockCID := flag.Uint("vsock-cid", 2, "vsock context ID (2 = host)")
-	vsockPort := flag.Uint("vsock-port", 8080, "vsock port")
+
+	// vsock mode
+	vsockCID := flag.Uint("vsock-cid", 0, "vsock context ID (2 = host)")
+	vsockPort := flag.Uint("vsock-port", 0, "vsock port")
+
+	// TLS proxy mode
+	proxyAddr := flag.String("proxy-addr", "", "TCP address of Warden proxy (TLS mode)")
+	clientCert := flag.String("client-cert", "", "client certificate for proxy mTLS (PEM)")
+	clientKey := flag.String("client-key", "", "client key for proxy mTLS (PEM)")
+	proxyCA := flag.String("proxy-ca", "", "CA certificate to verify proxy server (PEM)")
+
 	flag.Parse()
 
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	slog.SetDefault(logger)
+
+	dialer, mode, err := buildDialer(*vsockCID, *vsockPort, *proxyAddr, *clientCert, *clientKey, *proxyCA)
+	if err != nil {
+		slog.Error("configuration error", "error", err)
+		os.Exit(1)
+	}
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
@@ -31,28 +49,73 @@ func main() {
 	}
 	defer l.Close()
 
-	const maxUint32 = 1<<32 - 1
-	if *vsockCID > maxUint32 || *vsockPort > maxUint32 {
-		slog.Error("vsock CID and port must fit in uint32")
-		os.Exit(1)
-	}
-	cid := uint32(*vsockCID)   // #nosec G115 -- bounds checked above
-	port := uint32(*vsockPort) // #nosec G115 -- bounds checked above
-	dialer := &bridge.VsockDialer{
-		CID:  cid,
-		Port: port,
-	}
-
 	b := bridge.New(l, dialer, logger)
 
-	slog.Info("warden-bridge starting",
-		"listen", *listenAddr,
-		"vsock_cid", *vsockCID,
-		"vsock_port", *vsockPort,
-	)
+	logAttrs := []any{"listen", *listenAddr, "mode", mode}
+	if mode == "vsock" {
+		logAttrs = append(logAttrs, "vsock_cid", *vsockCID, "vsock_port", *vsockPort)
+	} else {
+		logAttrs = append(logAttrs, "proxy_addr", *proxyAddr)
+	}
+	slog.Info("warden-bridge starting", logAttrs...)
 
 	if err := b.Serve(ctx); err != nil {
 		slog.Error("bridge error", "error", err)
 		os.Exit(1)
 	}
+}
+
+func buildDialer(vsockCID, vsockPort uint, proxyAddr, certPath, keyPath, caPath string) (bridge.Dialer, string, error) {
+	vsockMode := vsockCID > 0 || vsockPort > 0
+	tlsMode := proxyAddr != ""
+
+	if vsockMode && tlsMode {
+		return nil, "", fmt.Errorf("cannot use both vsock and TLS proxy mode")
+	}
+	if !vsockMode && !tlsMode {
+		return nil, "", fmt.Errorf("specify either --vsock-cid/--vsock-port or --proxy-addr")
+	}
+
+	if vsockMode {
+		const maxUint32 = 1<<32 - 1
+		if vsockCID > maxUint32 || vsockPort > maxUint32 {
+			return nil, "", fmt.Errorf("vsock CID and port must fit in uint32")
+		}
+		cid := uint32(vsockCID)   // #nosec G115 -- bounds checked above
+		port := uint32(vsockPort) // #nosec G115 -- bounds checked above
+		return &bridge.VsockDialer{CID: cid, Port: port}, "vsock", nil
+	}
+
+	if certPath == "" || keyPath == "" {
+		return nil, "", fmt.Errorf("--client-cert and --client-key required for TLS proxy mode")
+	}
+
+	if _, err := tls.LoadX509KeyPair(certPath, keyPath); err != nil {
+		return nil, "", fmt.Errorf("loading client certificate: %w", err)
+	}
+
+	tlsCfg := &tls.Config{
+		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+			if err != nil {
+				return nil, err
+			}
+			return &cert, nil
+		},
+		MinVersion: tls.VersionTLS12,
+	}
+
+	if caPath != "" {
+		caPEM, err := os.ReadFile(caPath)
+		if err != nil {
+			return nil, "", fmt.Errorf("reading proxy CA: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caPEM) {
+			return nil, "", fmt.Errorf("no valid certificates found in %s", caPath)
+		}
+		tlsCfg.RootCAs = pool
+	}
+
+	return &bridge.TLSDialer{Addr: proxyAddr, TLSConfig: tlsCfg}, "tls", nil
 }

--- a/cmd/warden-bridge/main.go
+++ b/cmd/warden-bridge/main.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"github.com/rsturla/warden/internal/bridge"
@@ -106,7 +107,7 @@ func buildDialer(vsockCID, vsockPort uint, proxyAddr, certPath, keyPath, caPath 
 	}
 
 	if caPath != "" {
-		caPEM, err := os.ReadFile(caPath)
+		caPEM, err := os.ReadFile(filepath.Clean(caPath))
 		if err != nil {
 			return nil, "", fmt.Errorf("reading proxy CA: %w", err)
 		}

--- a/cmd/warden/main.go
+++ b/cmd/warden/main.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"flag"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
-
-	"fmt"
 
 	"github.com/rsturla/warden/internal/ca"
 	"github.com/rsturla/warden/internal/config"
@@ -21,6 +22,7 @@ import (
 	"github.com/rsturla/warden/internal/proxy"
 	"github.com/rsturla/warden/internal/secrets"
 	"github.com/rsturla/warden/internal/telemetry"
+	"github.com/rsturla/warden/internal/tenant"
 	"github.com/rsturla/warden/internal/version"
 )
 
@@ -60,17 +62,6 @@ func run(configPath string, logger *slog.Logger) error {
 		return err
 	}
 
-	// Secrets
-	var sources []secrets.SecretSource
-	for _, s := range cfg.Secrets {
-		src, err := secrets.Build(s)
-		if err != nil {
-			return err
-		}
-		sources = append(sources, src)
-	}
-	chain := secrets.NewChain(sources...)
-
 	// DNS
 	var baseResolver dns.Resolver
 	if cfg.DNS.DoT.Enabled {
@@ -88,12 +79,6 @@ func run(configPath string, logger *slog.Logger) error {
 		return err
 	}
 
-	// Policy
-	engine, err := policy.NewEngine(cfg.Policies)
-	if err != nil {
-		return err
-	}
-
 	// Telemetry
 	slogExporter := telemetry.NewSlogExporter(logger)
 	var exporter telemetry.TelemetryExporter = slogExporter
@@ -107,11 +92,38 @@ func run(configPath string, logger *slog.Logger) error {
 		exporter = telemetry.NewMultiExporter(slogExporter, otelExp)
 	}
 
-	// Proxy
+	// Tenant resolution
+	var tenantStore *tenant.FileStore
+	var tenantResolver proxy.TenantResolver
+
+	if cfg.Tenants != nil {
+		store, err := tenant.NewFileStore(cfg.Tenants.Dir)
+		if err != nil {
+			return err
+		}
+		tenantStore = store
+		tenantResolver = proxy.NewMTLSTenantResolver(store)
+	} else {
+		var sources []secrets.SecretSource
+		for _, s := range cfg.Secrets {
+			src, err := secrets.Build(s)
+			if err != nil {
+				return err
+			}
+			sources = append(sources, src)
+		}
+		chain := secrets.NewChain(sources...)
+
+		engine, err := policy.NewEngine(cfg.Policies)
+		if err != nil {
+			return err
+		}
+		tenantResolver = proxy.NewSingleTenantResolver(engine, chain)
+	}
+
 	p := proxy.New(proxy.Config{
 		CA:        wardenCA,
-		Policy:    engine,
-		Secrets:   chain,
+		Tenants:   tenantResolver,
 		Resolver:  dnsResolver,
 		Denylist:  denylist,
 		Telemetry: exporter,
@@ -119,26 +131,46 @@ func run(configPath string, logger *slog.Logger) error {
 
 	// Health
 	healthSrv := health.New()
+	if tenantStore != nil {
+		healthSrv.SetTenants(tenantStore)
+	}
 
 	// Listeners
 	proxyListener, err := listener.New(cfg.Server.Listen)
 	if err != nil {
 		return err
 	}
+
+	if cfg.Server.TLS != nil {
+		tlsConfig, err := buildServerTLS(cfg.Server.TLS)
+		if err != nil {
+			return err
+		}
+		proxyListener = tls.NewListener(proxyListener, tlsConfig)
+	}
+
 	healthListener, err := listener.New(cfg.Server.HealthListen)
 	if err != nil {
 		return err
 	}
 
-	logger.Info("warden starting",
+	logAttrs := []any{
 		"listen", cfg.Server.Listen,
 		"health_listen", cfg.Server.HealthListen,
-		"policies", len(cfg.Policies),
-		"secret_sources", len(cfg.Secrets),
-	)
+	}
+	if cfg.Tenants != nil {
+		logAttrs = append(logAttrs, "mode", "multi-tenant", "tenant_dir", cfg.Tenants.Dir)
+	} else {
+		logAttrs = append(logAttrs, "mode", "single-tenant", "policies", len(cfg.Policies), "secret_sources", len(cfg.Secrets))
+	}
+	logger.Info("warden starting", logAttrs...)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer cancel()
+
+	if tenantStore != nil {
+		go tenantStore.Watch(ctx, 30*time.Second)
+	}
 
 	proxySrv := &http.Server{
 		Handler:           p,
@@ -177,6 +209,39 @@ func run(configPath string, logger *slog.Logger) error {
 	if err := exporter.Close(shutdownCtx); err != nil {
 		logger.Error("telemetry close error", "error", err)
 	}
+	if tenantStore != nil {
+		_ = tenantStore.Close()
+	}
 
 	return nil
+}
+
+func buildServerTLS(cfg *config.ServerTLSConfig) (*tls.Config, error) {
+	if _, err := tls.LoadX509KeyPair(cfg.Cert, cfg.Key); err != nil {
+		return nil, fmt.Errorf("loading server TLS cert: %w", err)
+	}
+
+	clientCAPEM, err := os.ReadFile(cfg.ClientCA)
+	if err != nil {
+		return nil, fmt.Errorf("reading client CA: %w", err)
+	}
+
+	clientCAPool := x509.NewCertPool()
+	if !clientCAPool.AppendCertsFromPEM(clientCAPEM) {
+		return nil, fmt.Errorf("no valid certificates found in %s", cfg.ClientCA)
+	}
+
+	certPath, keyPath := cfg.Cert, cfg.Key
+	return &tls.Config{
+		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+			if err != nil {
+				return nil, err
+			}
+			return &cert, nil
+		},
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs:  clientCAPool,
+		MinVersion: tls.VersionTLS12,
+	}, nil
 }

--- a/config.multi-tenant.example.yaml
+++ b/config.multi-tenant.example.yaml
@@ -1,0 +1,30 @@
+server:
+  listen: "0.0.0.0:8443"
+  health_listen: "0.0.0.0:9090"
+  tls:
+    cert: /etc/warden/server.crt
+    key: /etc/warden/server.key
+    client_ca: /etc/warden/tenant-ca.crt
+
+ca:
+  cert: /etc/warden/mitm-ca.crt
+  key: /etc/warden/mitm-ca.key
+
+dns:
+  servers: ["8.8.8.8:53"]
+  cache:
+    enabled: true
+    max_ttl: 300
+  deny_resolved_ips:
+    - "169.254.169.254/32"
+    - "10.0.0.0/8"
+    - "172.16.0.0/12"
+    - "192.168.0.0/16"
+
+tenants:
+  dir: /etc/warden/tenants.d/
+
+telemetry:
+  logs:
+    level: info
+    format: json

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,12 +1,12 @@
 # Configuration Reference
 
-Warden is configured via a single YAML file, passed with `--config`.
+Warden is configured via a YAML file, passed with `--config`. Warden supports two modes: **single-tenant** (one config file with policies and secrets) and **multi-tenant** (global config + per-tenant config files with mTLS identification).
 
 ```bash
 warden --config /etc/warden/config.yaml
 ```
 
-## Full Configuration
+## Full Configuration (Single-Tenant)
 
 ```yaml
 server:
@@ -117,3 +117,105 @@ ca:
 ```
 
 If both `cert`/`key` and `auto` are set, the external CA takes precedence.
+
+## Multi-Tenant Mode
+
+Multi-tenant mode allows a single Warden instance to serve multiple agents, each with isolated policies and secrets. Tenants are identified by mTLS client certificate CN (Common Name).
+
+### Directory layout
+
+```
+/etc/warden/
+├── config.yaml              # Global config (server, CA, DNS, telemetry)
+└── tenants.d/               # Per-tenant configs
+    ├── agent-alpha.yaml     # CN=agent-alpha
+    ├── agent-beta.yaml      # CN=agent-beta
+    └── ci-runner.yaml       # CN=ci-runner
+```
+
+### Global config (multi-tenant)
+
+When `tenants` is set, root-level `policies` and `secrets` must be omitted — they live in per-tenant files.
+
+```yaml
+server:
+  listen: "0.0.0.0:8443"
+  health_listen: "0.0.0.0:9090"
+  tls:
+    cert: /etc/warden/server.crt           # Warden's server certificate
+    key: /etc/warden/server.key            # Warden's server key
+    client_ca: /etc/warden/tenant-ca.crt   # CA that signed agent client certs
+
+ca:
+  cert: /etc/warden/mitm-ca.crt
+  key: /etc/warden/mitm-ca.key
+
+dns:
+  cache:
+    enabled: true
+  deny_resolved_ips:
+    - "169.254.169.254/32"
+    - "10.0.0.0/8"
+
+tenants:
+  dir: /etc/warden/tenants.d/
+
+telemetry:
+  logs:
+    level: info
+```
+
+### Per-tenant config
+
+Each file in the tenant directory defines policies and secrets for one tenant. The filename (without extension) is the tenant ID, which must match the client certificate CN.
+
+```yaml
+# tenants.d/agent-alpha.yaml
+policies:
+  - name: allow-github
+    host: "api.github.com"
+    path: "/repos/acme/**"
+    action: allow
+    inject:
+      headers:
+        Authorization: "Bearer ${GITHUB_TOKEN}"
+
+secrets:
+  - type: vault
+    address: https://vault.internal:8200
+    prefix: agents/alpha/
+    auth: kubernetes
+```
+
+### Server TLS
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `server.tls.cert` | yes | PEM-encoded server certificate |
+| `server.tls.key` | yes | PEM-encoded server private key |
+| `server.tls.client_ca` | yes | CA certificate for verifying client certs |
+
+**Note:** `server.tls` configures TLS on the proxy listener (agent→Warden). This is separate from the `ca` section, which configures the MITM CA for HTTPS interception (Warden→upstream).
+
+### Tenants
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `tenants.dir` | yes | Directory containing per-tenant YAML files |
+
+### Hot reload
+
+Warden polls the tenant directory every 30 seconds. Changes take effect without restart:
+- New file → tenant available
+- Deleted file → tenant rejected (403)
+- Modified file → new policies/secrets applied
+
+In-flight requests complete with the old configuration. Failed reloads (invalid YAML, bad policy) are logged and the previous config is preserved.
+
+### Validation rules (multi-tenant)
+
+- `tenants` requires `server.tls` (mTLS is mandatory for tenant identification)
+- `server.tls` requires all three fields: `cert`, `key`, `client_ca`
+- Root-level `policies` must be empty when `tenants` is set
+- Root-level `secrets` must be empty when `tenants` is set
+- Per-tenant files follow the same policy/secret validation as single-tenant mode

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -265,6 +265,360 @@ Warden auto-generates a CA certificate on startup and writes it to `cert_output`
 
 Option 2 (external CA via ConfigMap) is recommended for production — the CA is stable across restarts and can be distributed before Warden starts.
 
+## Multi-Tenant Kubernetes (Shared Warden)
+
+A single Warden pod serves multiple agent pods. Each agent is identified by mTLS client certificate. Policies and secrets are isolated per tenant.
+
+```
+┌──────────────────────────┐
+│ Agent Pod A              │
+│ ┌────────┐ ┌───────────┐ │     ┌─────────────────┐
+│ │ Agent  │→│  Bridge   │─┼─mTLS→│                 │
+│ │        │ │ (sidecar) │ │     │  Warden Pod     │
+│ │HTTP_   │ │ cert:     │ │     │  (Deployment)   │
+│ │PROXY=  │ │ alpha.crt │ │     │                 │
+│ │local   │ └───────────┘ │     │  tenants.d/     │
+│ └────────┘               │     │  ├─ alpha.yaml  │
+└──────────────────────────┘     │  └─ beta.yaml   │
+                                 │                 │
+┌──────────────────────────┐     │  server.tls:    │
+│ Agent Pod B              │     │   client_ca     │──▶ upstream
+│ ┌────────┐ ┌───────────┐ │     │                 │
+│ │ Agent  │→│  Bridge   │─┼─mTLS→│                 │
+│ │        │ │ cert:     │ │     └─────────────────┘
+│ └────────┘ │ beta.crt  │ │          Service:
+│            └───────────┘ │       warden:8443
+└──────────────────────────┘
+```
+
+### Warden Deployment (multi-tenant)
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: warden-config
+  namespace: agent-sandbox
+data:
+  config.yaml: |
+    server:
+      listen: "0.0.0.0:8443"
+      health_listen: "0.0.0.0:9090"
+      tls:
+        cert: /etc/warden/tls/tls.crt
+        key: /etc/warden/tls/tls.key
+        client_ca: /etc/warden/tls/tenant-ca.crt
+    ca:
+      cert: /etc/warden/mitm/ca.crt
+      key: /etc/warden/mitm/ca.key
+    dns:
+      cache:
+        enabled: true
+      deny_resolved_ips:
+        - "169.254.169.254/32"
+        - "10.0.0.0/8"
+        - "172.16.0.0/12"
+        - "192.168.0.0/16"
+    tenants:
+      dir: /etc/warden/tenants.d/
+    telemetry:
+      logs:
+        level: info
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: warden-tenants
+  namespace: agent-sandbox
+data:
+  agent-alpha.yaml: |
+    policies:
+      - name: allow-github
+        host: "api.github.com"
+        path: "/repos/acme/**"
+        methods: ["GET", "POST"]
+        action: allow
+        inject:
+          headers:
+            Authorization: "Bearer ${ALPHA_GITHUB_TOKEN}"
+    secrets:
+      - type: env
+  agent-beta.yaml: |
+    policies:
+      - name: allow-pypi
+        host: "pypi.org"
+        methods: ["GET"]
+        action: allow
+    secrets:
+      - type: env
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: warden
+  namespace: agent-sandbox
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: warden
+  template:
+    metadata:
+      labels:
+        app: warden
+    spec:
+      volumes:
+        - name: config
+          configMap:
+            name: warden-config
+        - name: tenants
+          configMap:
+            name: warden-tenants
+        - name: server-tls
+          secret:
+            secretName: warden-server-tls
+        - name: mitm-ca
+          secret:
+            secretName: warden-mitm-ca
+      containers:
+        - name: warden
+          image: warden:latest
+          args: ["-config", "/etc/warden/config.yaml"]
+          envFrom:
+            - secretRef:
+                name: warden-agent-secrets
+          ports:
+            - containerPort: 8443
+              name: proxy
+            - containerPort: 9090
+              name: health
+          volumeMounts:
+            - name: config
+              mountPath: /etc/warden
+            - name: tenants
+              mountPath: /etc/warden/tenants.d
+            - name: server-tls
+              mountPath: /etc/warden/tls
+            - name: mitm-ca
+              mountPath: /etc/warden/mitm
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9090
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 9090
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: warden
+  namespace: agent-sandbox
+spec:
+  selector:
+    app: warden
+  ports:
+    - name: proxy
+      port: 8443
+      targetPort: proxy
+    - name: health
+      port: 9090
+      targetPort: health
+```
+
+### Agent with bridge sidecar
+
+Each agent pod runs a `warden-bridge` sidecar that handles mTLS to Warden. The agent uses the bridge as a plain HTTP proxy on localhost.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-alpha
+  namespace: agent-sandbox
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: agent-alpha
+  template:
+    metadata:
+      labels:
+        app: agent-alpha
+        role: agent
+    spec:
+      volumes:
+        - name: client-cert
+          secret:
+            secretName: agent-alpha-cert
+        - name: mitm-ca
+          configMap:
+            name: warden-mitm-ca-pub
+      containers:
+        - name: agent
+          image: my-agent:latest
+          env:
+            - name: HTTP_PROXY
+              value: "http://127.0.0.1:8080"
+            - name: HTTPS_PROXY
+              value: "http://127.0.0.1:8080"
+            - name: SSL_CERT_FILE
+              value: "/etc/warden-ca/ca.crt"
+          volumeMounts:
+            - name: mitm-ca
+              mountPath: /etc/warden-ca
+
+        - name: bridge
+          image: warden:latest
+          command: ["warden-bridge"]
+          args:
+            - "--listen=127.0.0.1:8080"
+            - "--proxy-addr=warden.agent-sandbox.svc:8443"
+            - "--client-cert=/etc/certs/tls.crt"
+            - "--client-key=/etc/certs/tls.key"
+            - "--proxy-ca=/etc/certs/ca.crt"
+          volumeMounts:
+            - name: client-cert
+              mountPath: /etc/certs
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 32Mi
+```
+
+### Client certificate provisioning
+
+Use [cert-manager](https://cert-manager.io/) to automate client certificate creation:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: tenant-ca-issuer
+  namespace: agent-sandbox
+spec:
+  ca:
+    secretName: tenant-ca-keypair
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: agent-alpha-cert
+  namespace: agent-sandbox
+spec:
+  secretName: agent-alpha-cert
+  commonName: agent-alpha
+  usages:
+    - client auth
+  issuerRef:
+    name: tenant-ca-issuer
+```
+
+Each `Certificate` resource creates a Kubernetes Secret containing `tls.crt`, `tls.key`, and `ca.crt`. The bridge sidecar mounts this Secret directly.
+
+### NetworkPolicy (multi-tenant)
+
+All agents share the same egress rule — they can only reach the Warden Service.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: agent-egress
+  namespace: agent-sandbox
+spec:
+  podSelector:
+    matchLabels:
+      role: agent
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: warden
+      ports:
+        - port: 8443
+          protocol: TCP
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: warden-ingress
+  namespace: agent-sandbox
+spec:
+  podSelector:
+    matchLabels:
+      app: warden
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              role: agent
+      ports:
+        - port: 8443
+          protocol: TCP
+```
+
+### Adding a new agent
+
+1. Create a `Certificate` resource (cert-manager generates the Secret)
+2. Add tenant config to the `warden-tenants` ConfigMap
+3. Deploy agent pod with bridge sidecar referencing the cert Secret
+
+ConfigMap updates propagate to mounted volumes automatically (~60s kubelet sync). Warden's hot reload detects the new tenant file within ~30s. No restarts needed.
+
+### Per-tenant secrets from Vault
+
+For production, use [external-secrets-operator](https://external-secrets.io/) to sync per-tenant secrets from Vault into a single Kubernetes Secret that Warden reads via `env`:
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: warden-agent-secrets
+  namespace: agent-sandbox
+spec:
+  secretStoreRef:
+    name: vault-backend
+  target:
+    name: warden-agent-secrets
+  data:
+    - secretKey: ALPHA_GITHUB_TOKEN
+      remoteRef:
+        key: agents/alpha/github
+        property: token
+    - secretKey: BETA_GITHUB_TOKEN
+      remoteRef:
+        key: agents/beta/github
+        property: token
+```
+
+Tenant configs reference these as `${ALPHA_GITHUB_TOKEN}`, `${BETA_GITHUB_TOKEN}`, etc. Each tenant's policy only references its own variables — the `env` source is shared but tenants cannot see each other's variable names because injection only happens for variables referenced in that tenant's policies.
+
 ## Same-Pod Sidecar (Alternative)
 
 For simpler deployments where NetworkPolicy enforcement is not required, the agent and Warden can run in the same pod. They communicate over `localhost` TCP. Note that without NetworkPolicy isolation, the agent could bypass Warden and connect directly to external services.
@@ -388,6 +742,74 @@ export NODE_EXTRA_CA_CERTS=/shared/warden-ca.crt
 export REQUESTS_CA_BUNDLE=/shared/warden-ca.crt
 ```
 
+## Multi-Tenant Deployment (mTLS)
+
+A single Warden instance can serve multiple agents, each identified by mTLS client certificate. Each agent gets isolated policies and secrets. See [Configuration](configuration.md) for config format.
+
+### Certificate setup
+
+Three certificate concerns, all independent:
+
+| Certificate | Purpose | Per-tenant? |
+|-------------|---------|-------------|
+| Server cert (`server.tls.cert`) | Warden's identity to agents | No, one for Warden |
+| Client cert (on each agent) | Agent identity to Warden | Yes, one per agent |
+| MITM CA (`ca.cert`) | HTTPS interception | No, shared |
+
+Generate a tenant CA and per-agent client certificates:
+
+```bash
+# Tenant CA (signs all agent client certs)
+openssl ecparam -genkey -name prime256v1 -out tenant-ca.key
+openssl req -new -x509 -key tenant-ca.key -out tenant-ca.crt -days 365 \
+  -subj "/CN=Warden Tenant CA"
+
+# Per-agent client cert (CN = tenant ID = config filename)
+openssl ecparam -genkey -name prime256v1 -out agent-alpha.key
+openssl req -new -key agent-alpha.key -out agent-alpha.csr \
+  -subj "/CN=agent-alpha"
+openssl x509 -req -in agent-alpha.csr -CA tenant-ca.crt -CAkey tenant-ca.key \
+  -CAcreateserial -out agent-alpha.crt -days 365
+```
+
+### Agent connection via warden-bridge
+
+Most HTTP clients don't support proxy client certificates natively. Use `warden-bridge` in TLS mode as a local forwarder:
+
+```bash
+# On agent machine — bridge handles mTLS to Warden
+warden-bridge \
+  --listen 127.0.0.1:8080 \
+  --proxy-addr warden.internal:8443 \
+  --client-cert /etc/certs/agent-alpha.crt \
+  --client-key /etc/certs/agent-alpha.key \
+  --proxy-ca /etc/certs/tenant-ca.crt
+
+# Agent uses bridge as plain HTTP proxy
+export HTTP_PROXY=http://127.0.0.1:8080
+export HTTPS_PROXY=http://127.0.0.1:8080
+```
+
+```
+Agent process ──HTTP──▶ localhost:8080 (bridge) ──mTLS──▶ Warden :8443
+                        adds client cert                  extracts CN
+                        automatically                     applies tenant config
+```
+
+### warden-bridge flags
+
+| Flag | Description |
+|------|-------------|
+| `--listen` | Local TCP listen address (default: `127.0.0.1:8080`) |
+| `--vsock-cid` | vsock context ID (vsock mode) |
+| `--vsock-port` | vsock port (vsock mode) |
+| `--proxy-addr` | Warden proxy TCP address (TLS mode) |
+| `--client-cert` | Client certificate PEM for mTLS (TLS mode, required) |
+| `--client-key` | Client key PEM for mTLS (TLS mode, required) |
+| `--proxy-ca` | CA to verify Warden's server cert (TLS mode, optional) |
+
+Modes are mutually exclusive: use either `--vsock-cid`/`--vsock-port` or `--proxy-addr`.
+
 ## Health Checks
 
 Warden exposes health endpoints on a separate port so agents cannot access them through the proxy.
@@ -396,6 +818,7 @@ Warden exposes health endpoints on a separate port so agents cannot access them 
 |----------|-------------|
 | `GET /healthz` | Liveness — Warden process is running |
 | `GET /readyz` | Readiness — config loaded, CA initialized |
+| `GET /tenantz` | Tenant list — loaded tenant IDs and count (multi-tenant mode only, 404 in single-tenant) |
 
 ```yaml
 server:

--- a/docs/development.md
+++ b/docs/development.md
@@ -72,9 +72,10 @@ internal/
   inject/              Header/query injection, ${VAR} template resolution
   listener/            TCP + vsock listener factory, connection limiter
   policy/              PolicyEngine interface, host/path glob, first-match-wins
-  proxy/               HTTP forward proxy + HTTPS CONNECT MITM handler
+  proxy/               HTTP forward proxy + HTTPS CONNECT MITM handler, TenantResolver
   secrets/             SecretSource implementations
   telemetry/           TelemetryExporter implementations
+  tenant/              Tenant store, per-tenant config, file-based store with hot reload
   version/             Version/commit/date vars (injected via ldflags)
 ```
 
@@ -111,6 +112,31 @@ type TelemetryExporter interface {
 }
 ```
 
+### TenantResolver
+
+```go
+type TenantResolver interface {
+    Resolve(r *http.Request) (*resolvedTenant, error)
+}
+```
+
+Determines which tenant's policies and secrets apply to a request. Every request goes through `TenantResolver` — there is no shortcut to access policies or secrets directly. Implementations:
+
+- **SingleTenantResolver** — returns the same tenant for every request (single-tenant mode, no TLS required)
+- **MTLSTenantResolver** — extracts tenant ID from the client certificate CN, looks up the tenant store
+
+### Tenant Store
+
+```go
+type Store interface {
+    Get(ctx context.Context, tenantID string) (*Tenant, error)
+    List(ctx context.Context) ([]string, error)
+    Close() error
+}
+```
+
+Manages per-tenant configuration (policies + secrets). Implementation: `FileStore` (loads YAML files from a directory, supports hot reload via polling).
+
 ## Adding Features
 
 ### New secret backend
@@ -130,6 +156,18 @@ type TelemetryExporter interface {
 
 1. Implement `TelemetryExporter` in `internal/telemetry/`
 2. Wire it in `cmd/warden/main.go` via `MultiExporter`
+
+### New tenant resolver
+
+1. Implement `TenantResolver` in `internal/proxy/resolver.go`
+2. Wire it in `cmd/warden/main.go` based on config
+
+### New tenant store backend
+
+1. Implement `tenant.Store` in `internal/tenant/` (e.g., `pgstore.go` for Postgres)
+2. Add config struct and validation in `internal/config/config.go`
+3. Wire it in `cmd/warden/main.go`
+4. The `FileStore` implementation is a good reference — see `internal/tenant/filestore.go`
 
 ## Code Conventions
 

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -104,6 +104,12 @@ inject:
 
 For HTTPS connections, Warden performs a fast check at the `CONNECT` stage — before the TLS handshake. If no allow rule could possibly match the requested host, Warden immediately returns `403` without spending resources on TLS. This is powered by `PolicyEngine.CanMatchHost()`.
 
+## Multi-Tenant Isolation
+
+In multi-tenant mode, each tenant has its own policy list defined in a separate config file (`tenants.d/<tenant-id>.yaml`). Policies are fully isolated — tenant A's rules cannot affect tenant B's requests. See [Configuration](configuration.md) for the per-tenant config format.
+
+Policy evaluation works identically per-tenant: first match wins, default deny. The tenant is resolved from the mTLS client certificate before any policy evaluation occurs.
+
 ## Security Considerations
 
 - **Default-deny**: no implicit allow. Every allowed endpoint must be explicitly listed.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -183,6 +183,12 @@ For GitHub Enterprise Server, set the `GITHUB_API_BASE` environment variable:
 export GITHUB_API_BASE=https://github.example.com/api/v3
 ```
 
+## Multi-Tenant Isolation
+
+In multi-tenant mode, each tenant has its own secret sources defined in its config file (`tenants.d/<tenant-id>.yaml`). Secret chains are fully isolated — tenant A cannot access tenant B's secrets.
+
+**Note:** the `env` source reads process-wide environment variables, which are shared across all tenants. For strict isolation, use `vault` or `file` sources with tenant-specific paths (e.g., different Vault prefixes per tenant).
+
 ## Source Chain
 
 Sources are checked in config order. The first source that resolves a variable wins. If a source returns an error (not "not found", but an actual error), resolution stops and the request is denied.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -30,6 +30,7 @@ Every proxied request produces a log entry:
   "time": "2026-04-25T12:00:00Z",
   "level": "INFO",
   "msg": "request",
+  "tenant_id": "agent-alpha",
   "client_ip": "10.0.0.5",
   "host": "api.github.com",
   "method": "GET",
@@ -42,7 +43,7 @@ Every proxied request produces a log entry:
 }
 ```
 
-Denied requests log at `WARN` level and include a `reason` field (`no_match` or the deny rule name). Fields with empty/zero values are omitted.
+Denied requests log at `WARN` level and include a `reason` field (`no_match` or the deny rule name). Fields with empty/zero values are omitted. The `tenant_id` field is present in multi-tenant mode and empty in single-tenant mode.
 
 **Secret values are never logged.** Only variable names appear in `injected_secrets`.
 
@@ -60,6 +61,7 @@ Every proxied request generates a root span `warden.proxy` with attributes:
 | `http.status_code` | Upstream response status (allow only) |
 | `warden.action` | `allow` or `deny` |
 | `warden.policy` | Matching policy rule name |
+| `warden.tenant_id` | Tenant ID (multi-tenant mode only) |
 | `net.peer.ip` | Client IP address |
 
 Denied requests have span status `ERROR` with the denial reason as the message.
@@ -92,7 +94,7 @@ OTLP/HTTP JSON export with cumulative aggregation.
 
 | Metric | Labels | Description |
 |--------|--------|-------------|
-| `warden.requests.total` | `http.method`, `warden.action` | Total proxied requests |
+| `warden.requests.total` | `http.method`, `warden.action`, `warden.tenant_id` | Total proxied requests |
 | `warden.requests.denied` | `reason` | Denied requests |
 
 ### Histograms

--- a/examples/tenants.d/acme-agent.yaml
+++ b/examples/tenants.d/acme-agent.yaml
@@ -1,0 +1,21 @@
+policies:
+  - name: block-metadata
+    host: "169.254.169.254"
+    action: deny
+
+  - name: allow-github
+    host: "api.github.com"
+    path: "/repos/acme/**"
+    methods: ["GET", "POST"]
+    action: allow
+    inject:
+      headers:
+        Authorization: "Bearer ${GITHUB_TOKEN}"
+
+  - name: allow-pypi
+    host: "pypi.org"
+    methods: ["GET"]
+    action: allow
+
+secrets:
+  - type: env

--- a/internal/bridge/tls.go
+++ b/internal/bridge/tls.go
@@ -1,0 +1,17 @@
+package bridge
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+)
+
+type TLSDialer struct {
+	Addr      string
+	TLSConfig *tls.Config
+}
+
+func (d *TLSDialer) Dial(ctx context.Context) (net.Conn, error) {
+	dialer := &tls.Dialer{Config: d.TLSConfig}
+	return dialer.DialContext(ctx, "tcp", d.Addr)
+}

--- a/internal/bridge/tls_test.go
+++ b/internal/bridge/tls_test.go
@@ -1,0 +1,428 @@
+package bridge
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestTLSDialer(t *testing.T) {
+	serverKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+	certDER, _ := x509.CreateCertificate(rand.Reader, template, template, &serverKey.PublicKey, serverKey)
+	serverCert := tls.Certificate{
+		Certificate: [][]byte{certDER},
+		PrivateKey:  serverKey,
+	}
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		MinVersion:   tls.VersionTLS12,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_, _ = conn.Write([]byte("hello-tls"))
+	}()
+
+	certPool := x509.NewCertPool()
+	cert, _ := x509.ParseCertificate(certDER)
+	certPool.AddCert(cert)
+
+	dialer := &TLSDialer{
+		Addr: ln.Addr().String(),
+		TLSConfig: &tls.Config{
+			RootCAs: certPool,
+		},
+	}
+
+	conn, err := dialer.Dial(context.Background())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	buf, err := io.ReadAll(conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(buf) != "hello-tls" {
+		t.Errorf("got %q, want %q", buf, "hello-tls")
+	}
+}
+
+func TestTLSDialerWithClientCert(t *testing.T) {
+	caKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(1 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caCertDER, _ := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	caCert, _ := x509.ParseCertificate(caCertDER)
+
+	serverKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "server"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+	serverCertDER, _ := x509.CreateCertificate(rand.Reader, serverTemplate, caCert, &serverKey.PublicKey, caKey)
+	serverCert := tls.Certificate{
+		Certificate: [][]byte{serverCertDER},
+		PrivateKey:  serverKey,
+	}
+
+	clientKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject:      pkix.Name{CommonName: "test-agent"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientCertDER, _ := x509.CreateCertificate(rand.Reader, clientTemplate, caCert, &clientKey.PublicKey, caKey)
+	clientCertTLS := tls.Certificate{
+		Certificate: [][]byte{clientCertDER},
+		PrivateKey:  clientKey,
+	}
+
+	clientCAPool := x509.NewCertPool()
+	clientCAPool.AddCert(caCert)
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    clientCAPool,
+		MinVersion:   tls.VersionTLS12,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	var gotCN string
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		tlsConn := conn.(*tls.Conn)
+		if err := tlsConn.Handshake(); err != nil {
+			return
+		}
+		state := tlsConn.ConnectionState()
+		if len(state.PeerCertificates) > 0 {
+			gotCN = state.PeerCertificates[0].Subject.CommonName
+		}
+		_, _ = conn.Write([]byte("authed"))
+	}()
+
+	serverCAPool := x509.NewCertPool()
+	serverCAPool.AddCert(caCert)
+
+	dialer := &TLSDialer{
+		Addr: ln.Addr().String(),
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{clientCertTLS},
+			RootCAs:      serverCAPool,
+		},
+	}
+
+	conn, err := dialer.Dial(context.Background())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	buf, err := io.ReadAll(conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(buf) != "authed" {
+		t.Errorf("got %q, want %q", buf, "authed")
+	}
+	if gotCN != "test-agent" {
+		t.Errorf("server saw CN = %q, want %q", gotCN, "test-agent")
+	}
+}
+
+func TestTLSDialerClientCertReload(t *testing.T) {
+	caKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(1 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caCertDER, _ := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	caCert, _ := x509.ParseCertificate(caCertDER)
+
+	genClientCert := func(cn string) (tls.Certificate, []byte, []byte) {
+		key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		template := &x509.Certificate{
+			SerialNumber: big.NewInt(time.Now().UnixNano()),
+			Subject:      pkix.Name{CommonName: cn},
+			NotBefore:    time.Now(),
+			NotAfter:     time.Now().Add(1 * time.Hour),
+			KeyUsage:     x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		}
+		certDER, _ := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+		certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+		keyDER, _ := x509.MarshalECPrivateKey(key)
+		keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+		tlsCert := tls.Certificate{Certificate: [][]byte{certDER}, PrivateKey: key}
+		return tlsCert, certPEM, keyPEM
+	}
+
+	serverKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "server"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+	serverCertDER, _ := x509.CreateCertificate(rand.Reader, serverTemplate, caCert, &serverKey.PublicKey, caKey)
+	serverCert := tls.Certificate{Certificate: [][]byte{serverCertDER}, PrivateKey: serverKey}
+
+	clientCAPool := x509.NewCertPool()
+	clientCAPool.AddCert(caCert)
+
+	cnCh := make(chan string, 10)
+	ln, _ := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    clientCAPool,
+		MinVersion:   tls.VersionTLS12,
+	})
+	defer ln.Close()
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			tlsConn := conn.(*tls.Conn)
+			if err := tlsConn.Handshake(); err != nil {
+				conn.Close()
+				continue
+			}
+			state := tlsConn.ConnectionState()
+			if len(state.PeerCertificates) > 0 {
+				cnCh <- state.PeerCertificates[0].Subject.CommonName
+			}
+			conn.Write([]byte("ok"))
+			conn.Close()
+		}
+	}()
+
+	// Write first cert to disk
+	certDir := t.TempDir()
+	certPath := certDir + "/client.crt"
+	keyPath := certDir + "/client.key"
+
+	_, certPEM1, keyPEM1 := genClientCert("agent-v1")
+	os.WriteFile(certPath, certPEM1, 0o600)
+	os.WriteFile(keyPath, keyPEM1, 0o600)
+
+	serverCAPool2 := x509.NewCertPool()
+	serverCAPool2.AddCert(caCert)
+
+	dialer := &TLSDialer{
+		Addr: ln.Addr().String(),
+		TLSConfig: &tls.Config{
+			GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+				cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+				if err != nil {
+					return nil, err
+				}
+				return &cert, nil
+			},
+			RootCAs: serverCAPool2,
+		},
+	}
+
+	// First connection — should see agent-v1
+	conn1, err := dialer.Dial(context.Background())
+	if err != nil {
+		t.Fatalf("first dial: %v", err)
+	}
+	io.ReadAll(conn1)
+	conn1.Close()
+
+	cn1 := <-cnCh
+	if cn1 != "agent-v1" {
+		t.Errorf("first connection CN = %q, want %q", cn1, "agent-v1")
+	}
+
+	// Replace cert on disk with new CN
+	_, certPEM2, keyPEM2 := genClientCert("agent-v2")
+	os.WriteFile(certPath, certPEM2, 0o600)
+	os.WriteFile(keyPath, keyPEM2, 0o600)
+
+	// Second connection — should see agent-v2 (reloaded from disk)
+	conn2, err := dialer.Dial(context.Background())
+	if err != nil {
+		t.Fatalf("second dial: %v", err)
+	}
+	io.ReadAll(conn2)
+	conn2.Close()
+
+	cn2 := <-cnCh
+	if cn2 != "agent-v2" {
+		t.Errorf("second connection CN = %q, want %q (cert was not reloaded)", cn2, "agent-v2")
+	}
+}
+
+func TestTLSDialerServerCertReload(t *testing.T) {
+	caKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(1 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caCertDER, _ := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	caCert, _ := x509.ParseCertificate(caCertDER)
+
+	genServerCert := func(cn string) ([]byte, []byte) {
+		key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		template := &x509.Certificate{
+			SerialNumber: big.NewInt(time.Now().UnixNano()),
+			Subject:      pkix.Name{CommonName: cn},
+			NotBefore:    time.Now(),
+			NotAfter:     time.Now().Add(1 * time.Hour),
+			KeyUsage:     x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+		}
+		certDER, _ := x509.CreateCertificate(rand.Reader, template, caCert, &key.PublicKey, caKey)
+		certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+		keyDER, _ := x509.MarshalECPrivateKey(key)
+		keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+		return certPEM, keyPEM
+	}
+
+	certDir := t.TempDir()
+	certPath := certDir + "/server.crt"
+	keyPath := certDir + "/server.key"
+
+	certPEM1, keyPEM1 := genServerCert("server-v1")
+	os.WriteFile(certPath, certPEM1, 0o600)
+	os.WriteFile(keyPath, keyPEM1, 0o600)
+
+	ln, _ := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+			if err != nil {
+				return nil, err
+			}
+			return &cert, nil
+		},
+		MinVersion: tls.VersionTLS12,
+	})
+	defer ln.Close()
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			conn.Write([]byte("ok"))
+			conn.Close()
+		}
+	}()
+
+	caPool := x509.NewCertPool()
+	caPool.AddCert(caCert)
+
+	dial := func() string {
+		conn, err := tls.Dial("tcp", ln.Addr().String(), &tls.Config{RootCAs: caPool})
+		if err != nil {
+			t.Fatalf("dial: %v", err)
+		}
+		defer conn.Close()
+		io.ReadAll(conn)
+		return conn.ConnectionState().PeerCertificates[0].Subject.CommonName
+	}
+
+	// First connection — server-v1
+	cn1 := dial()
+	if cn1 != "server-v1" {
+		t.Errorf("first connection CN = %q, want %q", cn1, "server-v1")
+	}
+
+	// Replace server cert on disk
+	certPEM2, keyPEM2 := genServerCert("server-v2")
+	os.WriteFile(certPath, certPEM2, 0o600)
+	os.WriteFile(keyPath, keyPEM2, 0o600)
+
+	// Second connection — server-v2
+	cn2 := dial()
+	if cn2 != "server-v2" {
+		t.Errorf("second connection CN = %q, want %q (cert was not reloaded)", cn2, "server-v2")
+	}
+}
+
+func TestTLSDialerConnectionRefused(t *testing.T) {
+	dialer := &TLSDialer{
+		Addr: "127.0.0.1:1",
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+
+	_, err := dialer.Dial(context.Background())
+	if err == nil {
+		t.Fatal("expected error for refused connection")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,11 +17,23 @@ type Config struct {
 	Secrets   []SecretConfig  `yaml:"secrets"`
 	Policies  []PolicyRule    `yaml:"policies"`
 	Telemetry TelemetryConfig `yaml:"telemetry"`
+	Tenants   *TenantsConfig  `yaml:"tenants,omitempty"`
 }
 
 type ServerConfig struct {
-	Listen       string `yaml:"listen"`
-	HealthListen string `yaml:"health_listen"`
+	Listen       string           `yaml:"listen"`
+	HealthListen string           `yaml:"health_listen"`
+	TLS          *ServerTLSConfig `yaml:"tls,omitempty"`
+}
+
+type ServerTLSConfig struct {
+	Cert     string `yaml:"cert"`
+	Key      string `yaml:"key"`
+	ClientCA string `yaml:"client_ca"`
+}
+
+type TenantsConfig struct {
+	Dir string `yaml:"dir"`
 }
 
 type CAConfig struct {
@@ -228,5 +240,33 @@ func (c *Config) Validate() error {
 	if c.Telemetry.Metrics.Enabled && c.Telemetry.Metrics.Endpoint == "" {
 		return fmt.Errorf("telemetry.metrics.endpoint is required when metrics are enabled")
 	}
+
+	if c.Tenants != nil {
+		if c.Tenants.Dir == "" {
+			return fmt.Errorf("tenants.dir is required when tenants are configured")
+		}
+		if c.Server.TLS == nil {
+			return fmt.Errorf("server.tls is required when tenants are configured (mTLS needed for tenant identification)")
+		}
+		if len(c.Policies) > 0 {
+			return fmt.Errorf("root-level policies must be empty when tenants are configured (use per-tenant config files)")
+		}
+		if len(c.Secrets) > 0 {
+			return fmt.Errorf("root-level secrets must be empty when tenants are configured (use per-tenant config files)")
+		}
+	}
+
+	if c.Server.TLS != nil {
+		if c.Server.TLS.Cert == "" {
+			return fmt.Errorf("server.tls.cert is required")
+		}
+		if c.Server.TLS.Key == "" {
+			return fmt.Errorf("server.tls.key is required")
+		}
+		if c.Server.TLS.ClientCA == "" {
+			return fmt.Errorf("server.tls.client_ca is required")
+		}
+	}
+
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -403,6 +403,134 @@ policies:
 	}
 }
 
+func TestValidateTenantsRequiresTLS(t *testing.T) {
+	data := []byte(`
+tenants:
+  dir: /etc/warden/tenants.d
+`)
+	_, err := Parse(data)
+	if err == nil {
+		t.Fatal("expected error: tenants without server.tls")
+	}
+}
+
+func TestValidateTenantsRequiresDir(t *testing.T) {
+	data := []byte(`
+server:
+  tls:
+    cert: server.crt
+    key: server.key
+    client_ca: ca.crt
+tenants: {}
+`)
+	_, err := Parse(data)
+	if err == nil {
+		t.Fatal("expected error: tenants without dir")
+	}
+}
+
+func TestValidateTenantsRejectsPolicies(t *testing.T) {
+	data := []byte(`
+server:
+  tls:
+    cert: server.crt
+    key: server.key
+    client_ca: ca.crt
+tenants:
+  dir: /etc/warden/tenants.d
+policies:
+  - name: test
+    host: "example.com"
+    action: allow
+`)
+	_, err := Parse(data)
+	if err == nil {
+		t.Fatal("expected error: tenants with root-level policies")
+	}
+}
+
+func TestValidateTenantsRejectsSecrets(t *testing.T) {
+	data := []byte(`
+server:
+  tls:
+    cert: server.crt
+    key: server.key
+    client_ca: ca.crt
+tenants:
+  dir: /etc/warden/tenants.d
+secrets:
+  - type: env
+`)
+	_, err := Parse(data)
+	if err == nil {
+		t.Fatal("expected error: tenants with root-level secrets")
+	}
+}
+
+func TestValidateTenantsValid(t *testing.T) {
+	data := []byte(`
+server:
+  tls:
+    cert: server.crt
+    key: server.key
+    client_ca: ca.crt
+tenants:
+  dir: /etc/warden/tenants.d
+`)
+	cfg, err := Parse(data)
+	if err != nil {
+		t.Fatalf("valid tenant config rejected: %v", err)
+	}
+	if cfg.Tenants == nil {
+		t.Fatal("tenants should not be nil")
+	}
+	if cfg.Tenants.Dir != "/etc/warden/tenants.d" {
+		t.Errorf("tenants.dir = %q", cfg.Tenants.Dir)
+	}
+}
+
+func TestValidateServerTLSMissingCert(t *testing.T) {
+	data := []byte(`
+server:
+  tls:
+    key: server.key
+    client_ca: ca.crt
+policies: []
+`)
+	_, err := Parse(data)
+	if err == nil {
+		t.Fatal("expected error: TLS without cert")
+	}
+}
+
+func TestValidateServerTLSMissingKey(t *testing.T) {
+	data := []byte(`
+server:
+  tls:
+    cert: server.crt
+    client_ca: ca.crt
+policies: []
+`)
+	_, err := Parse(data)
+	if err == nil {
+		t.Fatal("expected error: TLS without key")
+	}
+}
+
+func TestValidateServerTLSMissingClientCA(t *testing.T) {
+	data := []byte(`
+server:
+  tls:
+    cert: server.crt
+    key: server.key
+policies: []
+`)
+	_, err := Parse(data)
+	if err == nil {
+		t.Fatal("expected error: TLS without client_ca")
+	}
+}
+
 func TestValidateEmptyMethodsList(t *testing.T) {
 	data := []byte(`
 policies:

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -1,17 +1,27 @@
 package health
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"sync/atomic"
 )
 
+type TenantLister interface {
+	List(ctx context.Context) ([]string, error)
+}
+
 type Server struct {
-	ready atomic.Bool
+	ready   atomic.Bool
+	tenants TenantLister
 }
 
 func New() *Server {
 	return &Server{}
+}
+
+func (s *Server) SetTenants(t TenantLister) {
+	s.tenants = t
 }
 
 func (s *Server) SetReady(v bool) {
@@ -22,6 +32,7 @@ func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", s.handleHealthz)
 	mux.HandleFunc("GET /readyz", s.handleReadyz)
+	mux.HandleFunc("GET /tenantz", s.handleTenantz)
 	return mux
 }
 
@@ -38,4 +49,20 @@ func (s *Server) handleReadyz(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_ = json.NewEncoder(w).Encode(map[string]string{"status": "not ready"})
 	}
+}
+
+func (s *Server) handleTenantz(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if s.tenants == nil {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "single-tenant mode"})
+		return
+	}
+	ids, err := s.tenants.List(r.Context())
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "failed to list tenants"})
+		return
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{"tenants": ids, "count": len(ids)})
 }

--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -1,6 +1,7 @@
 package health
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -95,6 +96,78 @@ func TestMethodNotAllowed(t *testing.T) {
 
 	if resp.StatusCode != 405 {
 		t.Errorf("POST /healthz status = %d, want 405", resp.StatusCode)
+	}
+}
+
+type stubLister struct {
+	ids []string
+}
+
+func (s *stubLister) List(_ context.Context) ([]string, error) {
+	return s.ids, nil
+}
+
+func TestTenantzSingleTenant(t *testing.T) {
+	s := New()
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/tenantz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 404 {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestTenantzMultiTenant(t *testing.T) {
+	s := New()
+	s.SetTenants(&stubLister{ids: []string{"alpha", "beta"}})
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/tenantz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d", resp.StatusCode)
+	}
+
+	var body map[string]any
+	json.NewDecoder(resp.Body).Decode(&body)
+	tenants, ok := body["tenants"].([]any)
+	if !ok {
+		t.Fatal("tenants field missing or wrong type")
+	}
+	if len(tenants) != 2 {
+		t.Errorf("tenant count = %d, want 2", len(tenants))
+	}
+	count, _ := body["count"].(float64)
+	if int(count) != 2 {
+		t.Errorf("count = %v, want 2", body["count"])
+	}
+}
+
+func TestTenantzEmpty(t *testing.T) {
+	s := New()
+	s.SetTenants(&stubLister{ids: []string{}})
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/tenantz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d", resp.StatusCode)
 	}
 }
 

--- a/internal/proxy/connect.go
+++ b/internal/proxy/connect.go
@@ -25,10 +25,15 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		port = "443"
 	}
 
-	// Early rejection: if no allow rule can match this host, reject before TLS handshake.
-	if !p.policy.CanMatchHost(host) {
+	rt, err := p.tenants.Resolve(r)
+	if err != nil {
+		p.writeError(w, http.StatusForbidden, "tenant resolution failed")
+		return
+	}
+
+	if !rt.policy.CanMatchHost(host) {
 		start := time.Now()
-		p.logDeny(r.Context(), r, &policy.PolicyDecision{Reason: "no_match"}, start)
+		p.logDeny(r.Context(), r, &policy.PolicyDecision{Reason: "no_match"}, rt.id, start)
 		p.writeError(w, http.StatusForbidden, "no matching policy")
 		return
 	}
@@ -76,15 +81,15 @@ func (p *Proxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		req.URL.Host = connectHost
 		req.RemoteAddr = r.RemoteAddr
 
-		p.handleDecryptedRequest(tlsConn, req, host, port)
+		p.handleDecryptedRequest(tlsConn, req, host, port, rt)
 	}
 }
 
-func (p *Proxy) handleDecryptedRequest(clientConn net.Conn, req *http.Request, host, port string) {
+func (p *Proxy) handleDecryptedRequest(clientConn net.Conn, req *http.Request, host, port string, rt *resolvedTenant) {
 	start := time.Now()
 	ctx := req.Context()
 
-	decision, err := p.policy.Evaluate(ctx, &policy.RequestContext{
+	decision, err := rt.policy.Evaluate(ctx, &policy.RequestContext{
 		Host:   host,
 		Path:   req.URL.Path,
 		Method: req.Method,
@@ -95,19 +100,19 @@ func (p *Proxy) handleDecryptedRequest(clientConn net.Conn, req *http.Request, h
 	}
 
 	if !decision.Allowed {
-		p.logDeny(ctx, req, decision, start)
+		p.logDeny(ctx, req, decision, rt.id, start)
 		writeHTTPError(clientConn, http.StatusForbidden, denyMessage(decision))
 		return
 	}
 
 	var injectResult *inject.Result
 	if decision.Inject != nil {
-		injectResult, err = inject.Apply(ctx, req, decision.Inject, p.secrets)
+		injectResult, err = inject.Apply(ctx, req, decision.Inject, rt.secrets)
 		if err != nil {
 			p.logDeny(ctx, req, &policy.PolicyDecision{
 				RuleName: decision.RuleName,
 				Reason:   "secret_resolution_failed",
-			}, start)
+			}, rt.id, start)
 			writeHTTPError(clientConn, http.StatusForbidden, "secret resolution failed")
 			return
 		}
@@ -140,7 +145,7 @@ func (p *Proxy) handleDecryptedRequest(clientConn net.Conn, req *http.Request, h
 		return
 	}
 
-	p.logAllow(ctx, req, decision, injectResult, resp.StatusCode, start)
+	p.logAllow(ctx, req, decision, injectResult, rt.id, resp.StatusCode, start)
 }
 
 func (p *Proxy) dialUpstream(ctx context.Context, host, port string) (net.Conn, error) {

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -16,12 +16,18 @@ func (p *Proxy) handleForward(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 	ctx := r.Context()
 
+	rt, err := p.tenants.Resolve(r)
+	if err != nil {
+		p.writeError(w, http.StatusForbidden, "tenant resolution failed")
+		return
+	}
+
 	host := r.URL.Hostname()
 	if host == "" {
 		host = r.Host
 	}
 
-	decision, err := p.policy.Evaluate(ctx, &policy.RequestContext{
+	decision, err := rt.policy.Evaluate(ctx, &policy.RequestContext{
 		Host:   host,
 		Path:   r.URL.Path,
 		Method: r.Method,
@@ -32,19 +38,19 @@ func (p *Proxy) handleForward(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !decision.Allowed {
-		p.logDeny(ctx, r, decision, start)
+		p.logDeny(ctx, r, decision, rt.id, start)
 		p.writeError(w, http.StatusForbidden, denyMessage(decision))
 		return
 	}
 
 	var injectResult *inject.Result
 	if decision.Inject != nil {
-		injectResult, err = inject.Apply(ctx, r, decision.Inject, p.secrets)
+		injectResult, err = inject.Apply(ctx, r, decision.Inject, rt.secrets)
 		if err != nil {
 			p.logDeny(ctx, r, &policy.PolicyDecision{
 				RuleName: decision.RuleName,
 				Reason:   "secret_resolution_failed",
-			}, start)
+			}, rt.id, start)
 			p.writeError(w, http.StatusForbidden, "secret resolution failed")
 			return
 		}
@@ -72,14 +78,15 @@ func (p *Proxy) handleForward(w http.ResponseWriter, r *http.Request) {
 	_ = http.NewResponseController(w).Flush()
 	_ = copyBody(w, resp.Body)
 
-	p.logAllow(ctx, r, decision, injectResult, resp.StatusCode, start)
+	p.logAllow(ctx, r, decision, injectResult, rt.id, resp.StatusCode, start)
 }
 
-func (p *Proxy) logAllow(ctx context.Context, r *http.Request, d *policy.PolicyDecision, inj *inject.Result, status int, start time.Time) {
+func (p *Proxy) logAllow(ctx context.Context, r *http.Request, d *policy.PolicyDecision, inj *inject.Result, tenantID string, status int, start time.Time) {
 	if p.telemetry == nil {
 		return
 	}
 	entry := telemetry.RequestLog{
+		TenantID:       tenantID,
 		ClientIP:       clientIP(r),
 		Host:           requestHost(r),
 		Method:         r.Method,
@@ -95,7 +102,7 @@ func (p *Proxy) logAllow(ctx context.Context, r *http.Request, d *policy.PolicyD
 	_ = p.telemetry.LogRequest(ctx, entry)
 }
 
-func (p *Proxy) logDeny(ctx context.Context, r *http.Request, d *policy.PolicyDecision, start time.Time) {
+func (p *Proxy) logDeny(ctx context.Context, r *http.Request, d *policy.PolicyDecision, tenantID string, start time.Time) {
 	if p.telemetry == nil {
 		return
 	}
@@ -104,6 +111,7 @@ func (p *Proxy) logDeny(ctx context.Context, r *http.Request, d *policy.PolicyDe
 		reason = "no_match"
 	}
 	_ = p.telemetry.LogRequest(ctx, telemetry.RequestLog{
+		TenantID:   tenantID,
 		ClientIP:   clientIP(r),
 		Host:       requestHost(r),
 		Method:     r.Method,

--- a/internal/proxy/forward_test.go
+++ b/internal/proxy/forward_test.go
@@ -23,8 +23,7 @@ func startProxyWithDenylist(t *testing.T, rules []config.PolicyRule, secretVals 
 
 	p := New(Config{
 		CA:        ca,
-		Policy:    engine,
-		Secrets:   chain,
+		Tenants:   NewSingleTenantResolver(engine, chain),
 		Resolver:  resolver,
 		Denylist:  denylist,
 		Telemetry: &collectExporter{},

--- a/internal/proxy/multitenant_test.go
+++ b/internal/proxy/multitenant_test.go
@@ -1,0 +1,456 @@
+package proxy
+
+import (
+	"bufio"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	wardenca "github.com/rsturla/warden/internal/ca"
+	"github.com/rsturla/warden/internal/config"
+	wardendns "github.com/rsturla/warden/internal/dns"
+	"github.com/rsturla/warden/internal/policy"
+	"github.com/rsturla/warden/internal/secrets"
+	"github.com/rsturla/warden/internal/tenant"
+)
+
+type memoryStore struct {
+	tenants map[string]*tenant.Tenant
+}
+
+func (s *memoryStore) Get(_ context.Context, id string) (*tenant.Tenant, error) {
+	t, ok := s.tenants[id]
+	if !ok {
+		return nil, tenant.ErrTenantNotFound
+	}
+	return t, nil
+}
+
+func (s *memoryStore) List(_ context.Context) ([]string, error) {
+	ids := make([]string, 0, len(s.tenants))
+	for id := range s.tenants {
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func (s *memoryStore) Close() error { return nil }
+
+type testPKI struct {
+	caKey      *ecdsa.PrivateKey
+	caCert     *x509.Certificate
+	caCertPEM  []byte
+	serverCert tls.Certificate
+}
+
+func newTestPKI(t *testing.T) *testPKI {
+	t.Helper()
+	caKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test Tenant CA"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(1 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caCertDER, _ := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	caCert, _ := x509.ParseCertificate(caCertDER)
+	caCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertDER})
+
+	serverKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "warden-proxy"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+	serverCertDER, _ := x509.CreateCertificate(rand.Reader, serverTemplate, caCert, &serverKey.PublicKey, caKey)
+	serverCert := tls.Certificate{
+		Certificate: [][]byte{serverCertDER},
+		PrivateKey:  serverKey,
+	}
+
+	return &testPKI{
+		caKey:      caKey,
+		caCert:     caCert,
+		caCertPEM:  caCertPEM,
+		serverCert: serverCert,
+	}
+}
+
+func (pki *testPKI) clientCert(t *testing.T, cn string) tls.Certificate {
+	t.Helper()
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	certDER, _ := x509.CreateCertificate(rand.Reader, template, pki.caCert, &key.PublicKey, pki.caKey)
+	return tls.Certificate{
+		Certificate: [][]byte{certDER},
+		PrivateKey:  key,
+	}
+}
+
+func startMTLSProxy(t *testing.T, pki *testPKI, store tenant.Store) (string, *wardenca.CA, *collectExporter) {
+	t.Helper()
+	mitmCA, _ := wardenca.NewAutoCA("")
+	resolver := wardendns.NewStdlibResolver(nil)
+	denylist, _ := wardendns.NewDenylist(nil)
+	exp := &collectExporter{}
+
+	p := New(Config{
+		CA:        mitmCA,
+		Tenants:   NewMTLSTenantResolver(store),
+		Resolver:  resolver,
+		Denylist:  denylist,
+		Telemetry: exp,
+	})
+
+	clientCAPool := x509.NewCertPool()
+	clientCAPool.AddCert(pki.caCert)
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{pki.serverCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    clientCAPool,
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsLn := tls.NewListener(ln, tlsConfig)
+
+	srv := &http.Server{Handler: p}
+	go srv.Serve(tlsLn)
+	t.Cleanup(func() { srv.Close() })
+
+	return ln.Addr().String(), mitmCA, exp
+}
+
+func dialProxy(t *testing.T, addr string, pki *testPKI, clientCert tls.Certificate) *tls.Conn {
+	t.Helper()
+	serverCAPool := x509.NewCertPool()
+	serverCAPool.AddCert(pki.caCert)
+
+	conn, err := tls.Dial("tcp", addr, &tls.Config{
+		Certificates: []tls.Certificate{clientCert},
+		RootCAs:      serverCAPool,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return conn
+}
+
+func sendHTTPViaProxy(t *testing.T, conn net.Conn, method, fullURL string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(method, fullURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := req.WriteProxy(conn); err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(conn), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func TestMultiTenantForwardAllow(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("hello"))
+	}))
+	defer upstream.Close()
+
+	pki := newTestPKI(t)
+
+	upURL, _ := url.Parse(upstream.URL)
+
+	engineAlpha, _ := policy.NewYAMLPolicyEngine([]config.PolicyRule{
+		{Name: "allow", Host: upURL.Hostname(), Path: "/**", Action: "allow"},
+	})
+
+	store := &memoryStore{tenants: map[string]*tenant.Tenant{
+		"alpha": {ID: "alpha", Policy: engineAlpha, Secrets: secrets.NewChain()},
+	}}
+
+	addr, _, exp := startMTLSProxy(t, pki, store)
+
+	conn := dialProxy(t, addr, pki, pki.clientCert(t, "alpha"))
+	defer conn.Close()
+
+	resp := sendHTTPViaProxy(t, conn, "GET", upstream.URL+"/test")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "hello" {
+		t.Errorf("body = %q", body)
+	}
+
+	entries := exp.getEntries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(entries))
+	}
+	if entries[0].TenantID != "alpha" {
+		t.Errorf("tenant_id = %q, want %q", entries[0].TenantID, "alpha")
+	}
+	if entries[0].Action != "allow" {
+		t.Errorf("action = %q", entries[0].Action)
+	}
+}
+
+func TestMultiTenantForwardDeny(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("upstream should not be called")
+	}))
+	defer upstream.Close()
+	upURL, _ := url.Parse(upstream.URL)
+
+	pki := newTestPKI(t)
+
+	engineBeta, _ := policy.NewYAMLPolicyEngine([]config.PolicyRule{
+		{Name: "deny-all", Host: upURL.Hostname(), Path: "/**", Action: "deny"},
+	})
+
+	store := &memoryStore{tenants: map[string]*tenant.Tenant{
+		"beta": {ID: "beta", Policy: engineBeta, Secrets: secrets.NewChain()},
+	}}
+
+	addr, _, exp := startMTLSProxy(t, pki, store)
+
+	conn := dialProxy(t, addr, pki, pki.clientCert(t, "beta"))
+	defer conn.Close()
+
+	resp := sendHTTPViaProxy(t, conn, "GET", upstream.URL+"/test")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 403 {
+		t.Errorf("status = %d, want 403", resp.StatusCode)
+	}
+
+	entries := exp.getEntries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(entries))
+	}
+	if entries[0].TenantID != "beta" {
+		t.Errorf("tenant_id = %q, want %q", entries[0].TenantID, "beta")
+	}
+}
+
+func TestMultiTenantUnknownTenant(t *testing.T) {
+	pki := newTestPKI(t)
+	store := &memoryStore{tenants: map[string]*tenant.Tenant{}}
+
+	addr, _, _ := startMTLSProxy(t, pki, store)
+
+	conn := dialProxy(t, addr, pki, pki.clientCert(t, "unknown-agent"))
+	defer conn.Close()
+
+	resp := sendHTTPViaProxy(t, conn, "GET", "http://example.com/test")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 403 {
+		t.Errorf("status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestMultiTenantIsolation(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+	upURL, _ := url.Parse(upstream.URL)
+
+	pki := newTestPKI(t)
+
+	makeEngine := func() policy.PolicyEngine {
+		e, _ := policy.NewYAMLPolicyEngine([]config.PolicyRule{
+			{Name: "allow", Host: upURL.Hostname(), Path: "/**", Action: "allow",
+				Inject: &config.InjectConfig{Headers: map[string]string{"Authorization": "Bearer ${TOKEN}"}}},
+		})
+		return e
+	}
+
+	store := &memoryStore{tenants: map[string]*tenant.Tenant{
+		"alpha": {ID: "alpha", Policy: makeEngine(), Secrets: secrets.NewChain(&stubSource{values: map[string]string{"TOKEN": "alpha-secret"}})},
+		"beta":  {ID: "beta", Policy: makeEngine(), Secrets: secrets.NewChain(&stubSource{values: map[string]string{"TOKEN": "beta-secret"}})},
+	}}
+
+	addr, _, _ := startMTLSProxy(t, pki, store)
+
+	connAlpha := dialProxy(t, addr, pki, pki.clientCert(t, "alpha"))
+	defer connAlpha.Close()
+	resp := sendHTTPViaProxy(t, connAlpha, "GET", upstream.URL)
+	resp.Body.Close()
+	if gotAuth != "Bearer alpha-secret" {
+		t.Errorf("alpha auth = %q, want %q", gotAuth, "Bearer alpha-secret")
+	}
+
+	connBeta := dialProxy(t, addr, pki, pki.clientCert(t, "beta"))
+	defer connBeta.Close()
+	resp = sendHTTPViaProxy(t, connBeta, "GET", upstream.URL)
+	resp.Body.Close()
+	if gotAuth != "Bearer beta-secret" {
+		t.Errorf("beta auth = %q, want %q", gotAuth, "Bearer beta-secret")
+	}
+}
+
+func TestMultiTenantPolicyIsolation(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+	upURL, _ := url.Parse(upstream.URL)
+
+	pki := newTestPKI(t)
+
+	engineAlpha, _ := policy.NewYAMLPolicyEngine([]config.PolicyRule{
+		{Name: "api-only", Host: upURL.Hostname(), Path: "/api/**", Action: "allow"},
+	})
+	engineBeta, _ := policy.NewYAMLPolicyEngine([]config.PolicyRule{
+		{Name: "data-only", Host: upURL.Hostname(), Path: "/data/**", Action: "allow"},
+	})
+
+	store := &memoryStore{tenants: map[string]*tenant.Tenant{
+		"alpha": {ID: "alpha", Policy: engineAlpha, Secrets: secrets.NewChain()},
+		"beta":  {ID: "beta", Policy: engineBeta, Secrets: secrets.NewChain()},
+	}}
+
+	addr, _, _ := startMTLSProxy(t, pki, store)
+
+	// Alpha can access /api but not /data
+	connAlpha := dialProxy(t, addr, pki, pki.clientCert(t, "alpha"))
+	defer connAlpha.Close()
+
+	resp := sendHTTPViaProxy(t, connAlpha, "GET", upstream.URL+"/api/users")
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("alpha /api/users: status = %d, want 200", resp.StatusCode)
+	}
+
+	connAlpha2 := dialProxy(t, addr, pki, pki.clientCert(t, "alpha"))
+	defer connAlpha2.Close()
+
+	resp = sendHTTPViaProxy(t, connAlpha2, "GET", upstream.URL+"/data/files")
+	resp.Body.Close()
+	if resp.StatusCode != 403 {
+		t.Errorf("alpha /data/files: status = %d, want 403", resp.StatusCode)
+	}
+
+	// Beta can access /data but not /api
+	connBeta := dialProxy(t, addr, pki, pki.clientCert(t, "beta"))
+	defer connBeta.Close()
+
+	resp = sendHTTPViaProxy(t, connBeta, "GET", upstream.URL+"/data/files")
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("beta /data/files: status = %d, want 200", resp.StatusCode)
+	}
+
+	connBeta2 := dialProxy(t, addr, pki, pki.clientCert(t, "beta"))
+	defer connBeta2.Close()
+
+	resp = sendHTTPViaProxy(t, connBeta2, "GET", upstream.URL+"/api/users")
+	resp.Body.Close()
+	if resp.StatusCode != 403 {
+		t.Errorf("beta /api/users: status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestMultiTenantTelemetryTenantID(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+	upURL, _ := url.Parse(upstream.URL)
+
+	pki := newTestPKI(t)
+
+	engine, _ := policy.NewYAMLPolicyEngine([]config.PolicyRule{
+		{Name: "allow", Host: upURL.Hostname(), Path: "/**", Action: "allow"},
+	})
+
+	store := &memoryStore{tenants: map[string]*tenant.Tenant{
+		"agent-42": {ID: "agent-42", Policy: engine, Secrets: secrets.NewChain()},
+	}}
+
+	addr, _, exp := startMTLSProxy(t, pki, store)
+
+	conn := dialProxy(t, addr, pki, pki.clientCert(t, "agent-42"))
+	defer conn.Close()
+
+	resp := sendHTTPViaProxy(t, conn, "GET", upstream.URL+"/test")
+	resp.Body.Close()
+
+	entries := exp.getEntries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].TenantID != "agent-42" {
+		t.Errorf("tenant_id = %q, want %q", entries[0].TenantID, "agent-42")
+	}
+}
+
+func TestSingleTenantNoTenantID(t *testing.T) {
+	engine, _ := policy.NewYAMLPolicyEngine([]config.PolicyRule{
+		{Name: "allow", Host: "example.com", Path: "/**", Action: "allow"},
+	})
+	exp := &collectExporter{}
+
+	mitmCA, _ := wardenca.NewAutoCA("")
+	resolver := wardendns.NewStdlibResolver(nil)
+	denylist, _ := wardendns.NewDenylist(nil)
+
+	p := New(Config{
+		CA:        mitmCA,
+		Tenants:   NewSingleTenantResolver(engine, secrets.NewChain()),
+		Resolver:  resolver,
+		Denylist:  denylist,
+		Telemetry: exp,
+	})
+
+	req, _ := http.NewRequest("GET", "http://example.com/test", nil)
+	rr := httptest.NewRecorder()
+	p.ServeHTTP(rr, req)
+
+	entries := exp.getEntries()
+	if len(entries) == 0 {
+		t.Fatal("expected log entry")
+	}
+	if entries[0].TenantID != "" {
+		t.Errorf("single-tenant should have empty tenant_id, got %q", entries[0].TenantID)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -10,15 +10,12 @@ import (
 
 	wardenca "github.com/rsturla/warden/internal/ca"
 	wardendns "github.com/rsturla/warden/internal/dns"
-	"github.com/rsturla/warden/internal/policy"
-	"github.com/rsturla/warden/internal/secrets"
 	"github.com/rsturla/warden/internal/telemetry"
 )
 
 type Proxy struct {
 	ca        wardenca.CertProvider
-	policy    policy.PolicyEngine
-	secrets   *secrets.Chain
+	tenants   TenantResolver
 	resolver  wardendns.Resolver
 	denylist  *wardendns.Denylist
 	telemetry telemetry.TelemetryExporter
@@ -27,8 +24,7 @@ type Proxy struct {
 
 type Config struct {
 	CA        wardenca.CertProvider
-	Policy    policy.PolicyEngine
-	Secrets   *secrets.Chain
+	Tenants   TenantResolver
 	Resolver  wardendns.Resolver
 	Denylist  *wardendns.Denylist
 	Telemetry telemetry.TelemetryExporter
@@ -37,8 +33,7 @@ type Config struct {
 func New(cfg Config) *Proxy {
 	p := &Proxy{
 		ca:        cfg.CA,
-		policy:    cfg.Policy,
-		secrets:   cfg.Secrets,
+		tenants:   cfg.Tenants,
 		resolver:  cfg.Resolver,
 		denylist:  cfg.Denylist,
 		telemetry: cfg.Telemetry,

--- a/internal/proxy/proxy_fuzz_test.go
+++ b/internal/proxy/proxy_fuzz_test.go
@@ -25,8 +25,7 @@ func FuzzProxyRequest(f *testing.F) {
 
 	p := New(Config{
 		CA:       ca,
-		Policy:   engine,
-		Secrets:  chain,
+		Tenants:  NewSingleTenantResolver(engine, chain),
 		Resolver: resolver,
 		Denylist: denylist,
 	})

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"sync"
 	"testing"
+	"time"
 
 	wardenca "github.com/rsturla/warden/internal/ca"
 	"github.com/rsturla/warden/internal/config"
@@ -87,6 +88,21 @@ func (e *collectExporter) getEntries() []telemetry.RequestLog {
 	return cp
 }
 
+func (e *collectExporter) waitForEntries(t *testing.T, n int) []telemetry.RequestLog {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		entries := e.getEntries()
+		if len(entries) >= n {
+			return entries
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d log entries, got %d", n, len(entries))
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
 func TestForwardHTTPAllow(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("hello from upstream"))
@@ -116,11 +132,9 @@ func TestForwardHTTPAllow(t *testing.T) {
 		t.Errorf("body = %q", body)
 	}
 
-	if len(exp.getEntries()) != 1 {
-		t.Fatalf("expected 1 log entry, got %d", len(exp.getEntries()))
-	}
-	if exp.getEntries()[0].Action != "allow" {
-		t.Errorf("action = %q", exp.getEntries()[0].Action)
+	entries := exp.waitForEntries(t, 1)
+	if entries[0].Action != "allow" {
+		t.Errorf("action = %q", entries[0].Action)
 	}
 }
 
@@ -143,7 +157,8 @@ func TestForwardHTTPDeny(t *testing.T) {
 	if resp.StatusCode != 403 {
 		t.Errorf("status = %d, want 403", resp.StatusCode)
 	}
-	if len(exp.getEntries()) != 1 || exp.getEntries()[0].Action != "deny" {
+	entries := exp.waitForEntries(t, 1)
+	if entries[0].Action != "deny" {
 		t.Error("expected deny log entry")
 	}
 }
@@ -350,9 +365,9 @@ func TestConnectHTTPSDeny(t *testing.T) {
 
 	resp, err := client.Get("https://denied.example.com/test")
 	if err != nil {
-		// CONNECT succeeds but inner request gets 403 which may cause client error
-		if len(exp.getEntries()) > 0 && exp.getEntries()[0].Action == "deny" {
-			return
+		entries := exp.waitForEntries(t, 1)
+		if entries[0].Action != "deny" {
+			t.Errorf("expected deny, got %q", entries[0].Action)
 		}
 		return
 	}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -41,8 +41,7 @@ func startProxy(t *testing.T, rules []config.PolicyRule, secretVals map[string]s
 
 	proxy := New(Config{
 		CA:        ca,
-		Policy:    engine,
-		Secrets:   chain,
+		Tenants:   NewSingleTenantResolver(engine, chain),
 		Resolver:  resolver,
 		Denylist:  denylist,
 		Telemetry: exp,
@@ -237,8 +236,7 @@ func startProxyWithUpstreamTrust(t *testing.T, rules []config.PolicyRule, secret
 
 	p := New(Config{
 		CA:        ca,
-		Policy:    engine,
-		Secrets:   chain,
+		Tenants:   NewSingleTenantResolver(engine, chain),
 		Resolver:  resolver,
 		Denylist:  denylist,
 		Telemetry: exp,

--- a/internal/proxy/resolver.go
+++ b/internal/proxy/resolver.go
@@ -1,0 +1,62 @@
+package proxy
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/rsturla/warden/internal/policy"
+	"github.com/rsturla/warden/internal/secrets"
+	"github.com/rsturla/warden/internal/tenant"
+)
+
+type TenantResolver interface {
+	Resolve(r *http.Request) (*resolvedTenant, error)
+}
+
+type resolvedTenant struct {
+	id      string
+	policy  policy.PolicyEngine
+	secrets *secrets.Chain
+}
+
+type SingleTenantResolver struct {
+	tenant *resolvedTenant
+}
+
+func NewSingleTenantResolver(pol policy.PolicyEngine, sec *secrets.Chain) *SingleTenantResolver {
+	return &SingleTenantResolver{
+		tenant: &resolvedTenant{
+			policy:  pol,
+			secrets: sec,
+		},
+	}
+}
+
+func (r *SingleTenantResolver) Resolve(_ *http.Request) (*resolvedTenant, error) {
+	return r.tenant, nil
+}
+
+type MTLSTenantResolver struct {
+	store tenant.Store
+}
+
+func NewMTLSTenantResolver(store tenant.Store) *MTLSTenantResolver {
+	return &MTLSTenantResolver{store: store}
+}
+
+func (r *MTLSTenantResolver) Resolve(req *http.Request) (*resolvedTenant, error) {
+	if req.TLS == nil || len(req.TLS.PeerCertificates) == 0 {
+		return nil, errors.New("no client certificate")
+	}
+	tenantID := req.TLS.PeerCertificates[0].Subject.CommonName
+	t, err := r.store.Get(req.Context(), tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("tenant %q: %w", tenantID, err)
+	}
+	return &resolvedTenant{
+		id:      t.ID,
+		policy:  t.Policy,
+		secrets: t.Secrets,
+	}, nil
+}

--- a/internal/proxy/resolver_test.go
+++ b/internal/proxy/resolver_test.go
@@ -1,0 +1,128 @@
+package proxy
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/rsturla/warden/internal/config"
+	"github.com/rsturla/warden/internal/policy"
+	"github.com/rsturla/warden/internal/secrets"
+	"github.com/rsturla/warden/internal/tenant"
+)
+
+func TestSingleTenantResolverAlwaysReturns(t *testing.T) {
+	engine, _ := policy.NewYAMLPolicyEngine([]config.PolicyRule{
+		{Name: "test", Host: "example.com", Path: "/**", Action: "allow"},
+	})
+	chain := secrets.NewChain()
+
+	resolver := NewSingleTenantResolver(engine, chain)
+
+	r1, _ := http.NewRequest("GET", "http://example.com", nil)
+	rt1, err := resolver.Resolve(r1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r2, _ := http.NewRequest("POST", "http://other.com/path", nil)
+	rt2, err := resolver.Resolve(r2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if rt1 != rt2 {
+		t.Error("single tenant resolver should return same instance")
+	}
+	if rt1.id != "" {
+		t.Errorf("single tenant should have empty id, got %q", rt1.id)
+	}
+	if rt1.policy == nil {
+		t.Error("policy should not be nil")
+	}
+	if rt1.secrets == nil {
+		t.Error("secrets should not be nil")
+	}
+}
+
+func TestMTLSResolverNoCert(t *testing.T) {
+	store := &memoryStore{tenants: map[string]*tenant.Tenant{}}
+	resolver := NewMTLSTenantResolver(store)
+
+	r, _ := http.NewRequest("GET", "http://example.com", nil)
+	_, err := resolver.Resolve(r)
+	if err == nil {
+		t.Fatal("expected error for request without TLS")
+	}
+}
+
+func TestMTLSResolverNoPeerCerts(t *testing.T) {
+	store := &memoryStore{tenants: map[string]*tenant.Tenant{}}
+	resolver := NewMTLSTenantResolver(store)
+
+	r, _ := http.NewRequest("GET", "http://example.com", nil)
+	r.TLS = &tls.ConnectionState{}
+	_, err := resolver.Resolve(r)
+	if err == nil {
+		t.Fatal("expected error for TLS without peer certs")
+	}
+}
+
+func TestMTLSResolverValidCert(t *testing.T) {
+	engine, _ := policy.NewYAMLPolicyEngine(nil)
+	store := &memoryStore{tenants: map[string]*tenant.Tenant{
+		"agent-alpha": {ID: "agent-alpha", Policy: engine, Secrets: secrets.NewChain()},
+	}}
+	resolver := NewMTLSTenantResolver(store)
+
+	cert := makeCert(t, "agent-alpha")
+	r, _ := http.NewRequest("GET", "http://example.com", nil)
+	r.TLS = &tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{cert},
+	}
+
+	rt, err := resolver.Resolve(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rt.id != "agent-alpha" {
+		t.Errorf("tenant id = %q, want %q", rt.id, "agent-alpha")
+	}
+}
+
+func TestMTLSResolverUnknownTenant(t *testing.T) {
+	store := &memoryStore{tenants: map[string]*tenant.Tenant{}}
+	resolver := NewMTLSTenantResolver(store)
+
+	cert := makeCert(t, "unknown-agent")
+	r, _ := http.NewRequest("GET", "http://example.com", nil)
+	r.TLS = &tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{cert},
+	}
+
+	_, err := resolver.Resolve(r)
+	if err == nil {
+		t.Fatal("expected error for unknown tenant")
+	}
+}
+
+func makeCert(t *testing.T, cn string) *x509.Certificate {
+	t.Helper()
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+	}
+	certDER, _ := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	cert, _ := x509.ParseCertificate(certDER)
+	return cert
+}

--- a/internal/telemetry/otel.go
+++ b/internal/telemetry/otel.go
@@ -66,6 +66,20 @@ func NewOTELExporter(cfg OTELConfig) *OTELExporter {
 }
 
 func (e *OTELExporter) LogRequest(ctx context.Context, entry RequestLog) error {
+	spanAttrs := []otlpKeyValue{
+		{Key: "http.method", Value: otlpValue{StringValue: stringPtr(entry.Method)}},
+		{Key: "http.host", Value: otlpValue{StringValue: stringPtr(entry.Host)}},
+		{Key: "http.target", Value: otlpValue{StringValue: stringPtr(entry.Path)}},
+		{Key: "warden.action", Value: otlpValue{StringValue: stringPtr(entry.Action)}},
+		{Key: "warden.policy", Value: otlpValue{StringValue: stringPtr(entry.Policy)}},
+		{Key: "net.peer.ip", Value: otlpValue{StringValue: stringPtr(entry.ClientIP)}},
+	}
+	if entry.TenantID != "" {
+		spanAttrs = append(spanAttrs, otlpKeyValue{
+			Key: "warden.tenant_id", Value: otlpValue{StringValue: stringPtr(entry.TenantID)},
+		})
+	}
+
 	span := otlpSpan{
 		TraceID:           e.traceID,
 		SpanID:            generateSpanID(),
@@ -73,14 +87,7 @@ func (e *OTELExporter) LogRequest(ctx context.Context, entry RequestLog) error {
 		Kind:              3, // SERVER
 		StartTimeUnixNano: time.Now().Add(-time.Duration(entry.DurationMs) * time.Millisecond).UnixNano(),
 		EndTimeUnixNano:   time.Now().UnixNano(),
-		Attributes: []otlpKeyValue{
-			{Key: "http.method", Value: otlpValue{StringValue: stringPtr(entry.Method)}},
-			{Key: "http.host", Value: otlpValue{StringValue: stringPtr(entry.Host)}},
-			{Key: "http.target", Value: otlpValue{StringValue: stringPtr(entry.Path)}},
-			{Key: "warden.action", Value: otlpValue{StringValue: stringPtr(entry.Action)}},
-			{Key: "warden.policy", Value: otlpValue{StringValue: stringPtr(entry.Policy)}},
-			{Key: "net.peer.ip", Value: otlpValue{StringValue: stringPtr(entry.ClientIP)}},
-		},
+		Attributes:        spanAttrs,
 	}
 
 	if entry.UpstreamStatus > 0 {
@@ -323,6 +330,9 @@ func (e *OTELExporter) recordRequestMetrics(entry RequestLog) {
 	attrs := []MetricAttr{
 		{Key: "http.method", Value: entry.Method},
 		{Key: "warden.action", Value: entry.Action},
+	}
+	if entry.TenantID != "" {
+		attrs = append(attrs, MetricAttr{Key: "warden.tenant_id", Value: entry.TenantID})
 	}
 	e.RecordMetric(ctx, "warden.requests.total", 1, attrs...)
 	e.RecordMetric(ctx, "warden.request.duration_ms", float64(entry.DurationMs), attrs...)

--- a/internal/telemetry/slog.go
+++ b/internal/telemetry/slog.go
@@ -19,14 +19,20 @@ func (e *SlogExporter) LogRequest(ctx context.Context, entry RequestLog) error {
 		level = slog.LevelWarn
 	}
 
-	attrs := []slog.Attr{
+	attrs := []slog.Attr{}
+
+	if entry.TenantID != "" {
+		attrs = append(attrs, slog.String("tenant_id", entry.TenantID))
+	}
+
+	attrs = append(attrs,
 		slog.String("client_ip", entry.ClientIP),
 		slog.String("host", entry.Host),
 		slog.String("method", entry.Method),
 		slog.String("path", entry.Path),
 		slog.String("action", entry.Action),
 		slog.Int64("duration_ms", entry.DurationMs),
-	}
+	)
 
 	if entry.Policy != "" {
 		attrs = append(attrs, slog.String("policy", entry.Policy))

--- a/internal/telemetry/types.go
+++ b/internal/telemetry/types.go
@@ -26,6 +26,7 @@ type MetricAttr struct {
 }
 
 type RequestLog struct {
+	TenantID        string
 	ClientIP        string
 	Host            string
 	Method          string

--- a/internal/tenant/config.go
+++ b/internal/tenant/config.go
@@ -1,0 +1,64 @@
+package tenant
+
+import (
+	"fmt"
+
+	"github.com/rsturla/warden/internal/config"
+	"go.yaml.in/yaml/v3"
+)
+
+type TenantConfig struct {
+	Policies []config.PolicyRule   `yaml:"policies"`
+	Secrets  []config.SecretConfig `yaml:"secrets"`
+}
+
+func ParseTenantConfig(data []byte) (*TenantConfig, error) {
+	var tc TenantConfig
+	if err := yaml.Unmarshal(data, &tc); err != nil {
+		return nil, fmt.Errorf("parsing tenant config: %w", err)
+	}
+	if err := validateTenantConfig(&tc); err != nil {
+		return nil, err
+	}
+	applyTenantDefaults(&tc)
+	return &tc, nil
+}
+
+func applyTenantDefaults(tc *TenantConfig) {
+	for i := range tc.Policies {
+		if tc.Policies[i].Path == "" {
+			tc.Policies[i].Path = "/**"
+		}
+	}
+}
+
+func validateTenantConfig(tc *TenantConfig) error {
+	seen := make(map[string]bool)
+	for i, p := range tc.Policies {
+		if p.Name == "" {
+			return fmt.Errorf("policy %d: name is required", i)
+		}
+		if seen[p.Name] {
+			return fmt.Errorf("policy %q: duplicate name", p.Name)
+		}
+		seen[p.Name] = true
+		if p.Host == "" {
+			return fmt.Errorf("policy %q: host is required", p.Name)
+		}
+		if p.Action == "" {
+			return fmt.Errorf("policy %q: action is required", p.Name)
+		}
+		if p.Action != "allow" && p.Action != "deny" {
+			return fmt.Errorf("policy %q: action must be 'allow' or 'deny', got %q", p.Name, p.Action)
+		}
+		if p.Action == "deny" && p.Inject != nil {
+			return fmt.Errorf("policy %q: deny rules cannot have inject", p.Name)
+		}
+	}
+	for _, s := range tc.Secrets {
+		if s.Type == "" {
+			return fmt.Errorf("secret source: type is required")
+		}
+	}
+	return nil
+}

--- a/internal/tenant/config_fuzz_test.go
+++ b/internal/tenant/config_fuzz_test.go
@@ -1,0 +1,41 @@
+package tenant
+
+import "testing"
+
+func FuzzParseTenantConfig(f *testing.F) {
+	f.Add([]byte(`
+policies:
+  - name: test
+    host: "example.com"
+    action: allow
+secrets:
+  - type: env
+`))
+	f.Add([]byte(`policies: []`))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(``))
+	f.Add([]byte(`
+policies:
+  - name: test
+    host: "*.example.com"
+    path: "/api/**"
+    methods: ["GET", "POST"]
+    action: allow
+    inject:
+      headers:
+        Authorization: "Bearer ${TOKEN}"
+      query:
+        api_key: "${KEY}"
+secrets:
+  - type: vault
+    address: https://vault.example.com:8200
+    mount: secret
+    prefix: app/
+    auth: kubernetes
+`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// ParseTenantConfig must not panic on any input
+		_, _ = ParseTenantConfig(data)
+	})
+}

--- a/internal/tenant/config_test.go
+++ b/internal/tenant/config_test.go
@@ -1,0 +1,185 @@
+package tenant
+
+import (
+	"testing"
+)
+
+func TestParseTenantConfigValid(t *testing.T) {
+	data := []byte(`
+policies:
+  - name: allow-github
+    host: "api.github.com"
+    path: "/repos/**"
+    methods: ["GET", "POST"]
+    action: allow
+    inject:
+      headers:
+        Authorization: "Bearer ${TOKEN}"
+  - name: deny-internal
+    host: "internal.corp"
+    action: deny
+secrets:
+  - type: env
+`)
+	tc, err := ParseTenantConfig(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tc.Policies) != 2 {
+		t.Errorf("policies len = %d, want 2", len(tc.Policies))
+	}
+	if len(tc.Secrets) != 1 {
+		t.Errorf("secrets len = %d, want 1", len(tc.Secrets))
+	}
+	if tc.Policies[0].Inject == nil {
+		t.Fatal("policy 0 inject should not be nil")
+	}
+	if tc.Policies[0].Inject.Headers["Authorization"] != "Bearer ${TOKEN}" {
+		t.Errorf("inject header = %q", tc.Policies[0].Inject.Headers["Authorization"])
+	}
+}
+
+func TestParseTenantConfigPathDefault(t *testing.T) {
+	data := []byte(`
+policies:
+  - name: test
+    host: "example.com"
+    action: allow
+`)
+	tc, err := ParseTenantConfig(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tc.Policies[0].Path != "/**" {
+		t.Errorf("default path = %q, want %q", tc.Policies[0].Path, "/**")
+	}
+}
+
+func TestParseTenantConfigEmpty(t *testing.T) {
+	data := []byte(`
+policies: []
+secrets: []
+`)
+	tc, err := ParseTenantConfig(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tc.Policies) != 0 {
+		t.Errorf("expected empty policies")
+	}
+}
+
+func TestParseTenantConfigMissingName(t *testing.T) {
+	data := []byte(`
+policies:
+  - host: "example.com"
+    action: allow
+`)
+	_, err := ParseTenantConfig(data)
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+}
+
+func TestParseTenantConfigMissingHost(t *testing.T) {
+	data := []byte(`
+policies:
+  - name: test
+    action: allow
+`)
+	_, err := ParseTenantConfig(data)
+	if err == nil {
+		t.Fatal("expected error for missing host")
+	}
+}
+
+func TestParseTenantConfigMissingAction(t *testing.T) {
+	data := []byte(`
+policies:
+  - name: test
+    host: "example.com"
+`)
+	_, err := ParseTenantConfig(data)
+	if err == nil {
+		t.Fatal("expected error for missing action")
+	}
+}
+
+func TestParseTenantConfigInvalidAction(t *testing.T) {
+	data := []byte(`
+policies:
+  - name: test
+    host: "example.com"
+    action: maybe
+`)
+	_, err := ParseTenantConfig(data)
+	if err == nil {
+		t.Fatal("expected error for invalid action")
+	}
+}
+
+func TestParseTenantConfigDuplicateName(t *testing.T) {
+	data := []byte(`
+policies:
+  - name: test
+    host: "a.com"
+    action: allow
+  - name: test
+    host: "b.com"
+    action: deny
+`)
+	_, err := ParseTenantConfig(data)
+	if err == nil {
+		t.Fatal("expected error for duplicate name")
+	}
+}
+
+func TestParseTenantConfigDenyWithInject(t *testing.T) {
+	data := []byte(`
+policies:
+  - name: test
+    host: "example.com"
+    action: deny
+    inject:
+      headers:
+        X-Foo: bar
+`)
+	_, err := ParseTenantConfig(data)
+	if err == nil {
+		t.Fatal("expected error for deny with inject")
+	}
+}
+
+func TestParseTenantConfigInvalidYAML(t *testing.T) {
+	data := []byte(`{{{invalid`)
+	_, err := ParseTenantConfig(data)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+}
+
+func TestParseTenantConfigMissingSecretType(t *testing.T) {
+	data := []byte(`
+policies: []
+secrets:
+  - {}
+`)
+	_, err := ParseTenantConfig(data)
+	if err == nil {
+		t.Fatal("expected error for secret without type")
+	}
+}
+
+func TestParseTenantConfigNoPoliciesKey(t *testing.T) {
+	data := []byte(`
+secrets:
+  - type: env
+`)
+	tc, err := ParseTenantConfig(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tc.Policies) != 0 {
+		t.Errorf("expected empty policies, got %d", len(tc.Policies))
+	}
+}

--- a/internal/tenant/filestore.go
+++ b/internal/tenant/filestore.go
@@ -1,0 +1,218 @@
+package tenant
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rsturla/warden/internal/policy"
+	"github.com/rsturla/warden/internal/secrets"
+)
+
+type FileStore struct {
+	dir string
+
+	mu      sync.RWMutex
+	tenants map[string]*Tenant
+	hashes  map[string][32]byte
+}
+
+func NewFileStore(dir string) (*FileStore, error) {
+	fs := &FileStore{
+		dir:     dir,
+		tenants: make(map[string]*Tenant),
+		hashes:  make(map[string][32]byte),
+	}
+	if err := fs.loadAll(); err != nil {
+		return nil, fmt.Errorf("loading tenants from %s: %w", dir, err)
+	}
+	return fs, nil
+}
+
+func (fs *FileStore) Get(_ context.Context, tenantID string) (*Tenant, error) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+	t, ok := fs.tenants[tenantID]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrTenantNotFound, tenantID)
+	}
+	return t, nil
+}
+
+func (fs *FileStore) List(_ context.Context) ([]string, error) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+	ids := make([]string, 0, len(fs.tenants))
+	for id := range fs.tenants {
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func (fs *FileStore) Close() error {
+	return nil
+}
+
+func (fs *FileStore) Watch(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			fs.reload()
+		}
+	}
+}
+
+func (fs *FileStore) loadAll() error {
+	entries, err := os.ReadDir(fs.dir)
+	if err != nil {
+		return fmt.Errorf("reading directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !isYAML(entry.Name()) {
+			continue
+		}
+		if err := fs.loadFile(entry.Name()); err != nil {
+			return fmt.Errorf("tenant %s: %w", entry.Name(), err)
+		}
+	}
+	return nil
+}
+
+func (fs *FileStore) loadFile(filename string) error {
+	path := filepath.Join(fs.dir, filename)
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return fmt.Errorf("reading file: %w", err)
+	}
+
+	hash := sha256.Sum256(data)
+	tenantID := tenantIDFromFilename(filename)
+
+	tc, err := ParseTenantConfig(data)
+	if err != nil {
+		return err
+	}
+
+	t, err := buildTenant(tenantID, tc)
+	if err != nil {
+		return err
+	}
+
+	fs.tenants[tenantID] = t
+	fs.hashes[tenantID] = hash
+	return nil
+}
+
+func (fs *FileStore) reload() {
+	entries, err := os.ReadDir(fs.dir)
+	if err != nil {
+		slog.Error("tenant reload: reading directory", "error", err)
+		return
+	}
+
+	seen := make(map[string]bool)
+	for _, entry := range entries {
+		if entry.IsDir() || !isYAML(entry.Name()) {
+			continue
+		}
+
+		tenantID := tenantIDFromFilename(entry.Name())
+		seen[tenantID] = true
+
+		path := filepath.Join(fs.dir, entry.Name())
+		data, err := os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			slog.Error("tenant reload: reading file", "tenant", tenantID, "error", err)
+			continue
+		}
+
+		hash := sha256.Sum256(data)
+
+		fs.mu.RLock()
+		oldHash, exists := fs.hashes[tenantID]
+		fs.mu.RUnlock()
+
+		if exists && hash == oldHash {
+			continue
+		}
+
+		tc, err := ParseTenantConfig(data)
+		if err != nil {
+			slog.Error("tenant reload: parsing config", "tenant", tenantID, "error", err)
+			continue
+		}
+
+		t, err := buildTenant(tenantID, tc)
+		if err != nil {
+			slog.Error("tenant reload: building tenant", "tenant", tenantID, "error", err)
+			continue
+		}
+
+		fs.mu.Lock()
+		fs.tenants[tenantID] = t
+		fs.hashes[tenantID] = hash
+		fs.mu.Unlock()
+
+		if exists {
+			slog.Info("tenant reloaded", "tenant", tenantID)
+		} else {
+			slog.Info("tenant added", "tenant", tenantID)
+		}
+	}
+
+	fs.mu.Lock()
+	for id := range fs.tenants {
+		if !seen[id] {
+			delete(fs.tenants, id)
+			delete(fs.hashes, id)
+			slog.Info("tenant removed", "tenant", id)
+		}
+	}
+	fs.mu.Unlock()
+}
+
+func buildTenant(id string, tc *TenantConfig) (*Tenant, error) {
+	engine, err := policy.NewEngine(tc.Policies)
+	if err != nil {
+		return nil, fmt.Errorf("building policy engine: %w", err)
+	}
+
+	var sources []secrets.SecretSource
+	for _, s := range tc.Secrets {
+		src, err := secrets.Build(s)
+		if err != nil {
+			return nil, fmt.Errorf("building secret source %q: %w", s.Type, err)
+		}
+		sources = append(sources, src)
+	}
+	chain := secrets.NewChain(sources...)
+
+	return &Tenant{
+		ID:      id,
+		Policy:  engine,
+		Secrets: chain,
+	}, nil
+}
+
+func tenantIDFromFilename(filename string) string {
+	name := filepath.Base(filename)
+	for _, ext := range []string{".yaml", ".yml"} {
+		name = strings.TrimSuffix(name, ext)
+	}
+	return name
+}
+
+func isYAML(name string) bool {
+	return strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml")
+}

--- a/internal/tenant/filestore_test.go
+++ b/internal/tenant/filestore_test.go
@@ -1,0 +1,340 @@
+package tenant
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/rsturla/warden/internal/secrets"
+)
+
+const validTenantYAML = `
+policies:
+  - name: allow-github
+    host: "api.github.com"
+    path: "/repos/**"
+    action: allow
+secrets:
+  - type: env
+`
+
+const anotherTenantYAML = `
+policies:
+  - name: allow-pypi
+    host: "pypi.org"
+    action: allow
+`
+
+func writeTenantFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFileStoreLoadSingle(t *testing.T) {
+	dir := t.TempDir()
+	writeTenantFile(t, dir, "acme.yaml", validTenantYAML)
+
+	store, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	tenant, err := store.Get(context.Background(), "acme")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tenant.ID != "acme" {
+		t.Errorf("tenant ID = %q, want %q", tenant.ID, "acme")
+	}
+	if tenant.Policy == nil {
+		t.Error("policy should not be nil")
+	}
+	if tenant.Secrets == nil {
+		t.Error("secrets should not be nil")
+	}
+}
+
+func TestFileStoreLoadMultiple(t *testing.T) {
+	dir := t.TempDir()
+	writeTenantFile(t, dir, "acme.yaml", validTenantYAML)
+	writeTenantFile(t, dir, "beta.yml", anotherTenantYAML)
+
+	store, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ids, err := store.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("tenant count = %d, want 2", len(ids))
+	}
+
+	_, err = store.Get(context.Background(), "acme")
+	if err != nil {
+		t.Errorf("get acme: %v", err)
+	}
+	_, err = store.Get(context.Background(), "beta")
+	if err != nil {
+		t.Errorf("get beta: %v", err)
+	}
+}
+
+func TestFileStoreNotFound(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = store.Get(context.Background(), "nonexistent")
+	if !errors.Is(err, ErrTenantNotFound) {
+		t.Errorf("expected ErrTenantNotFound, got %v", err)
+	}
+}
+
+func TestFileStoreIgnoresNonYAML(t *testing.T) {
+	dir := t.TempDir()
+	writeTenantFile(t, dir, "acme.yaml", validTenantYAML)
+	writeTenantFile(t, dir, "readme.txt", "not a tenant")
+	writeTenantFile(t, dir, "notes.md", "also not a tenant")
+
+	store, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ids, err := store.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 1 {
+		t.Errorf("tenant count = %d, want 1", len(ids))
+	}
+}
+
+func TestFileStoreIgnoresSubdirectories(t *testing.T) {
+	dir := t.TempDir()
+	writeTenantFile(t, dir, "acme.yaml", validTenantYAML)
+	if err := os.Mkdir(filepath.Join(dir, "subdir.yaml"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ids, err := store.List(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 1 {
+		t.Errorf("tenant count = %d, want 1", len(ids))
+	}
+}
+
+func TestFileStoreInvalidConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeTenantFile(t, dir, "bad.yaml", `
+policies:
+  - host: "example.com"
+    action: allow
+`)
+
+	_, err := NewFileStore(dir)
+	if err == nil {
+		t.Fatal("expected error for invalid tenant config")
+	}
+}
+
+func TestFileStoreInvalidDirectory(t *testing.T) {
+	_, err := NewFileStore("/nonexistent/path")
+	if err == nil {
+		t.Fatal("expected error for nonexistent directory")
+	}
+}
+
+func TestFileStoreReloadAdd(t *testing.T) {
+	dir := t.TempDir()
+	writeTenantFile(t, dir, "acme.yaml", validTenantYAML)
+
+	store, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ids, _ := store.List(context.Background())
+	if len(ids) != 1 {
+		t.Fatalf("initial tenant count = %d, want 1", len(ids))
+	}
+
+	writeTenantFile(t, dir, "beta.yaml", anotherTenantYAML)
+	store.reload()
+
+	ids, _ = store.List(context.Background())
+	if len(ids) != 2 {
+		t.Errorf("post-reload tenant count = %d, want 2", len(ids))
+	}
+
+	_, err = store.Get(context.Background(), "beta")
+	if err != nil {
+		t.Errorf("get beta after reload: %v", err)
+	}
+}
+
+func TestFileStoreReloadRemove(t *testing.T) {
+	dir := t.TempDir()
+	writeTenantFile(t, dir, "acme.yaml", validTenantYAML)
+	writeTenantFile(t, dir, "beta.yaml", anotherTenantYAML)
+
+	store, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	os.Remove(filepath.Join(dir, "beta.yaml"))
+	store.reload()
+
+	ids, _ := store.List(context.Background())
+	if len(ids) != 1 {
+		t.Errorf("post-reload tenant count = %d, want 1", len(ids))
+	}
+
+	_, err = store.Get(context.Background(), "beta")
+	if !errors.Is(err, ErrTenantNotFound) {
+		t.Errorf("expected ErrTenantNotFound after removal, got %v", err)
+	}
+}
+
+func TestFileStoreReloadUpdate(t *testing.T) {
+	dir := t.TempDir()
+	writeTenantFile(t, dir, "acme.yaml", validTenantYAML)
+
+	store, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tenantBefore, _ := store.Get(context.Background(), "acme")
+
+	writeTenantFile(t, dir, "acme.yaml", anotherTenantYAML)
+	store.reload()
+
+	tenantAfter, _ := store.Get(context.Background(), "acme")
+
+	if tenantBefore.Policy == tenantAfter.Policy {
+		t.Error("policy should be different after reload with changed content")
+	}
+}
+
+func TestFileStoreReloadNoChangeSkips(t *testing.T) {
+	dir := t.TempDir()
+	writeTenantFile(t, dir, "acme.yaml", validTenantYAML)
+
+	store, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tenantBefore, _ := store.Get(context.Background(), "acme")
+	store.reload()
+	tenantAfter, _ := store.Get(context.Background(), "acme")
+
+	if tenantBefore != tenantAfter {
+		t.Error("unchanged tenant should keep same pointer")
+	}
+}
+
+func TestFileStoreReloadBadConfigKeepsOld(t *testing.T) {
+	dir := t.TempDir()
+	writeTenantFile(t, dir, "acme.yaml", validTenantYAML)
+
+	store, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tenantBefore, _ := store.Get(context.Background(), "acme")
+
+	writeTenantFile(t, dir, "acme.yaml", `{{{invalid`)
+	store.reload()
+
+	tenantAfter, err := store.Get(context.Background(), "acme")
+	if err != nil {
+		t.Fatal("bad reload should keep old tenant")
+	}
+	if tenantBefore != tenantAfter {
+		t.Error("failed reload should keep old tenant pointer")
+	}
+}
+
+func TestFileStoreWatchContext(t *testing.T) {
+	dir := t.TempDir()
+	writeTenantFile(t, dir, "acme.yaml", validTenantYAML)
+
+	store, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		store.Watch(ctx, 50*time.Millisecond)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Watch did not return after context cancel")
+	}
+}
+
+func TestFileStoreYMLExtension(t *testing.T) {
+	dir := t.TempDir()
+	writeTenantFile(t, dir, "gamma.yml", anotherTenantYAML)
+
+	store, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tenant, err := store.Get(context.Background(), "gamma")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tenant.ID != "gamma" {
+		t.Errorf("tenant ID = %q, want %q", tenant.ID, "gamma")
+	}
+}
+
+func TestTenantIDFromFilename(t *testing.T) {
+	tests := []struct {
+		filename string
+		want     string
+	}{
+		{"acme.yaml", "acme"},
+		{"acme.yml", "acme"},
+		{"my-agent.yaml", "my-agent"},
+		{"agent_001.yml", "agent_001"},
+		{"corp.dev.yaml", "corp.dev"},
+	}
+	for _, tt := range tests {
+		got := tenantIDFromFilename(tt.filename)
+		if got != tt.want {
+			t.Errorf("tenantIDFromFilename(%q) = %q, want %q", tt.filename, got, tt.want)
+		}
+	}
+}

--- a/internal/tenant/store.go
+++ b/internal/tenant/store.go
@@ -1,0 +1,14 @@
+package tenant
+
+import (
+	"context"
+	"errors"
+)
+
+var ErrTenantNotFound = errors.New("tenant not found")
+
+type Store interface {
+	Get(ctx context.Context, tenantID string) (*Tenant, error)
+	List(ctx context.Context) ([]string, error)
+	Close() error
+}

--- a/internal/tenant/tenant.go
+++ b/internal/tenant/tenant.go
@@ -1,0 +1,12 @@
+package tenant
+
+import (
+	"github.com/rsturla/warden/internal/policy"
+	"github.com/rsturla/warden/internal/secrets"
+)
+
+type Tenant struct {
+	ID      string
+	Policy  policy.PolicyEngine
+	Secrets *secrets.Chain
+}


### PR DESCRIPTION
## Summary

- **Multi-tenant mode**: a single Warden instance serves multiple agents, each identified by mTLS client certificate CN with isolated policies and secrets
- **TenantResolver interface**: all policy/secret access goes through `Resolve(r)` — impossible to bypass tenant isolation. Implementations: `SingleTenantResolver` (backward-compatible single-tenant) and `MTLSTenantResolver` (mTLS)
- **FileStore with hot reload**: per-tenant YAML configs loaded from a directory (filename = tenant ID), 30s polling with SHA-256 change detection
- **Server TLS + warden-bridge TLS mode**: proxy listener supports mTLS; bridge supports `--proxy-addr`/`--client-cert`/`--client-key`/`--proxy-ca` for agents that can't configure proxy client certs
- **Certificate hot reload**: both server and client certs re-read from disk on each TLS handshake via `GetCertificate`/`GetClientCertificate` callbacks (cert-manager compatible)
- **Telemetry**: `tenant_id` field in structured logs, OTLP traces, and metrics
- **Health**: `GET /tenantz` endpoint lists loaded tenants (404 in single-tenant mode)
- **Config validation**: `tenants` requires `server.tls`, rejects root-level `policies`/`secrets`
- **Full documentation**: configuration, deployment (including multi-tenant K8s with cert-manager), development, policies, secrets, telemetry all updated

### Architecture

```
TenantResolver (interface)           ← the ONLY way to access policy/secrets
├── SingleTenantResolver             ← single-tenant mode (backward compat)
└── MTLSTenantResolver               ← extracts CN from mTLS client cert
         └── tenant.Store (interface)
              └── FileStore          ← directory of YAML files, hot reload
```

### New packages/files

| Path | Purpose |
|------|---------|
| `internal/tenant/` | Tenant store, config parsing, FileStore with hot reload |
| `internal/proxy/resolver.go` | `TenantResolver` interface + implementations |
| `internal/bridge/tls.go` | `TLSDialer` for bridge mTLS connections |

### Backward compatibility

Single-tenant configs work unchanged. When no `tenants:` section is present, Warden uses `SingleTenantResolver` which returns the same policy/secrets for every request — identical to previous behavior.

## Test plan

- [x] 305+ unit tests pass (including 30+ new multi-tenancy tests)
- [x] Race detector clean (`make test-race`)
- [x] 11 fuzz targets pass (including new `FuzzParseTenantConfig`)
- [x] Lint clean (`go vet` + `staticcheck`)
- [x] E2E: single-tenant HTTP/HTTPS allow, deny, method deny, content passthrough
- [x] E2E: multi-tenant HTTP/HTTPS with per-tenant policy isolation via warden-bridge
- [x] E2E: credential isolation — each tenant gets own injected secrets, not other's
- [x] E2E: credential override protection — agent-supplied headers replaced by Warden's
- [x] E2E: tenant_id attribution in telemetry logs
- [x] E2E: hot reload — add/remove/update tenant configs without restart
- [x] E2E: unknown tenant rejected with 403
- [x] E2E: `/tenantz` health endpoint shows loaded tenants
- [x] Certificate reload tests — client and server certs re-read from disk on renewal

🤖 Generated with [Claude Code](https://claude.com/claude-code)